### PR TITLE
Added unit tests; replaced tabs by space

### DIFF
--- a/hpOneView/test/unit/test_networking.py
+++ b/hpOneView/test/unit/test_networking.py
@@ -30,146 +30,145 @@ from hpOneView.networking import *
 
 
 class NetworkingTest(unittest.TestCase):
+    def setUp(self):
+        super(NetworkingTest, self).setUp()
+        self.host = 'http://1.2.3.4'
+        self.connection = connection(self.host)
+        self.networking = networking(self.connection)
 
-	def setUp(self):
-		super(NetworkingTest, self).setUp()
-		self.host = 'http://1.2.3.4'
-		self.connection = connection(self.host)
-		self.networking = networking(self.connection)
+    @mock.patch.object(connection, 'get')
+    def test_get_lig_default_settings(self, mock_get):
+        self.networking.get_lig_default_settings()
+        mock_get.assert_called_once_with(uri['lig'] + '/defaultSettings')
 
-	@mock.patch.object(connection, 'get')
-	def test_get_lig_default_settings(self, mock_get):
-		self.networking.get_lig_default_settings()
-		mock_get.assert_called_once_with(uri['lig'] + '/defaultSettings')
+    @mock.patch.object(connection, 'get')
+    def test_get_lig_settings(self, mock_get):
+        id = uuid.uuid4()
+        self.networking.get_lig_settings(id)
+        lig_uri = uri['lig'] + '/{id}/settings'
+        mock_get.assert_called_once_with(lig_uri.format(id=id))
 
-	@mock.patch.object(connection, 'get')
-	def test_get_lig_settings(self, mock_get):
-		id = uuid.uuid4()
-		self.networking.get_lig_settings(id)
-		lig_uri = uri['lig'] + '/{id}/settings'
-		mock_get.assert_called_once_with(lig_uri.format(id=id))
+    @mock.patch.object(connection, 'get')
+    def test_get_lig_by_id(self, mock_get):
+        id = str(uuid.uuid4())
+        self.networking.get_lig_by_id(id)
+        mock_get.assert_called_once_with(uri['lig'] + '/' + id)
 
-	@mock.patch.object(connection, 'get')
-	def test_get_lig_by_id(self, mock_get):
-		id = str(uuid.uuid4())
-		self.networking.get_lig_by_id(id)
-		mock_get.assert_called_once_with(uri['lig'] + '/' + id)
+    @mock.patch.object(connection, 'get')
+    def test_get_lig_schema(self, mock_get):
+        self.networking.get_lig_schema()
+        mock_get.assert_called_once_with(uri['lig'] + '/schema')
 
-	@mock.patch.object(connection, 'get')
-	def test_get_lig_schema(self, mock_get):
-		self.networking.get_lig_schema()
-		mock_get.assert_called_once_with(uri['lig'] + '/schema')
+    @mock.patch.object(connection, 'get')
+    def test_get_logical_downlinks(self, mock_get):
+        self.networking.get_logical_downlinks()
+        mock_get.assert_called_once_with(uri['ld'])
+        mock_get.reset_mock()
 
-	@mock.patch.object(connection, 'get')
-	def test_get_logical_downlinks(self, mock_get):
-		self.networking.get_logical_downlinks()
-		mock_get.assert_called_once_with(uri['ld'])
-		mock_get.reset_mock()
+        # Testing with filter
+        filter = '?start=0&count=10'
+        self.networking.get_logical_downlinks(filter=filter)
+        mock_get.assert_called_once_with(uri['ld'] + filter)
 
-		# Testing with filter
-		filter = '?start=0&count=10'
-		self.networking.get_logical_downlinks(filter=filter)
-		mock_get.assert_called_once_with(uri['ld'] + filter)
+    @mock.patch.object(connection, 'get')
+    def test_get_logical_downlinks_schema(self, mock_get):
+        self.networking.get_logical_downlinks_schema()
+        mock_get.assert_called_once_with(uri['ld'] + '/schema')
 
-	@mock.patch.object(connection, 'get')
-	def test_get_logical_downlinks_schema(self, mock_get):
-		self.networking.get_logical_downlinks_schema()
-		mock_get.assert_called_once_with(uri['ld'] + '/schema')
+    @mock.patch.object(connection, 'get')
+    def test_get_logical_downlinks_without_ethernet(self, mock_get):
+        self.networking.get_logical_downlinks_without_ethernet()
+        downlinks_uri = uri['ld'] + '/withoutEthernet'
+        mock_get.assert_called_once_with(downlinks_uri)
+        mock_get.reset_mock()
 
-	@mock.patch.object(connection, 'get')
-	def test_get_logical_downlinks_without_ethernet(self, mock_get):
-		self.networking.get_logical_downlinks_without_ethernet()
-		downlinks_uri = uri['ld'] + '/withoutEthernet'
-		mock_get.assert_called_once_with(downlinks_uri)
-		mock_get.reset_mock()
+        # Testing with filter
+        filter = '?start=0&count=10'
+        self.networking.get_logical_downlinks_without_ethernet(filter=filter)
+        mock_get.assert_called_once_with(downlinks_uri + filter)
 
-		# Testing with filter
-		filter = '?start=0&count=10'
-		self.networking.get_logical_downlinks_without_ethernet(filter=filter)
-		mock_get.assert_called_once_with(downlinks_uri + filter)
+    @mock.patch.object(connection, 'get')
+    def test_get_logical_downlink_by_id(self, mock_get):
+        id = str(uuid.uuid4())
+        self.networking.get_logical_downlink(id)
+        mock_get.assert_called_once_with(uri['ld'] + '/' + id)
 
-	@mock.patch.object(connection, 'get')
-	def test_get_logical_downlink_by_id(self, mock_get):
-		id = str(uuid.uuid4())
-		self.networking.get_logical_downlink(id)
-		mock_get.assert_called_once_with(uri['ld'] + '/' + id)
+    @mock.patch.object(connection, 'get')
+    def test_get_logical_downlink_without_ethernet_by_id(self, mock_get):
+        id = str(uuid.uuid4())
+        self.networking.get_logical_downlink_without_ethernet(id)
+        downlink_uri = uri['ld'] + '/{id}/withoutEthernet'
+        mock_get.assert_called_once_with(downlink_uri.format(id=id))
 
-	@mock.patch.object(connection, 'get')
-	def test_get_logical_downlink_without_ethernet_by_id(self, mock_get):
-		id = str(uuid.uuid4())
-		self.networking.get_logical_downlink_without_ethernet(id)
-		downlink_uri = uri['ld'] + '/{id}/withoutEthernet'
-		mock_get.assert_called_once_with(downlink_uri.format(id=id))
+    @mock.patch.object(connection, 'get')
+    def test_get_logical_interconnects(self, mock_get):
+        self.networking.get_lis()
+        mock_get.assert_called_once_with(uri['li'])
+        mock_get.reset_mock()
 
-	@mock.patch.object(connection, 'get')
-	def test_get_logical_interconnects(self, mock_get):
-		self.networking.get_lis()
-		mock_get.assert_called_once_with(uri['li'])
-		mock_get.reset_mock()
+        # Testing with filter
+        filter = '?start=0&count=10'
+        self.networking.get_lis(filter=filter)
+        mock_get.assert_called_once_with(uri['li'] + filter)
 
-		# Testing with filter
-		filter = '?start=0&count=10'
-		self.networking.get_lis(filter=filter)
-		mock_get.assert_called_once_with(uri['li'] + filter)
+    @mock.patch.object(connection, 'put')
+    def test_correct_lis(self, mock_put):
+        uris = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
+        mock_put.return_value = (None, None)
+        request = {'uris': uris}
 
-	@mock.patch.object(connection, 'put')
-	def test_correct_lis(self, mock_put):
-		uris = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
-		mock_put.return_value = (None, None)
-		request = {'uris': uris}
+        # passing blocking as False because we just want to test the uri.
+        self.networking.correct_lis(uris, blocking=False)
+        mock_put.assert_called_once_with(uri['li'] + '/compliance', request)
 
-		# passing blocking as False because we just want to test the uri.
-		self.networking.correct_lis(uris, blocking=False)
-		mock_put.assert_called_once_with(uri['li'] + '/compliance', request)
+    @mock.patch.object(connection, 'post')
+    def test_create_li(self, mock_post):
+        location_entries = [uuid.uuid4().hex, uuid.uuid4().hex]
+        mock_post.return_value = (None, None)
+        request = {'locationEntries': location_entries}
 
-	@mock.patch.object(connection, 'post')
-	def test_create_li(self, mock_post):
-		location_entries = [uuid.uuid4().hex, uuid.uuid4().hex]
-		mock_post.return_value = (None, None)
-		request = {'locationEntries': location_entries}
+        # passing blocking as False because we just want to test the uri.
+        self.networking.create_li(location_entries, blocking=False)
+        mock_post.assert_called_once_with(
+            uri['li'] + '/locations/interconnects', request)
 
-		# passing blocking as False because we just want to test the uri.
-		self.networking.create_li(location_entries, blocking=False)
-		mock_post.assert_called_once_with(
-			uri['li'] + '/locations/interconnects', request)
+    @mock.patch.object(connection, 'delete')
+    def test_delete_li(self, mock_delete):
+        # the host where the li will be deleted.
+        location = self.host
+        mock_delete.return_value = (None, None)
 
-	@mock.patch.object(connection, 'delete')
-	def test_delete_li(self, mock_delete):
-		# the host where the li will be deleted.
-		location = self.host
-		mock_delete.return_value = (None, None)
+        # passing blocking as False because we just want to test the uri.
+        self.networking.delete_li(location, blocking=False)
+        mock_delete.assert_called_once_with(
+            uri['li'] + '/locations/interconnects?location=' + location)
 
-		# passing blocking as False because we just want to test the uri.
-		self.networking.delete_li(location, blocking=False)
-		mock_delete.assert_called_once_with(
-			uri['li'] + '/locations/interconnects?location=' + location)
+    @mock.patch.object(connection, 'get')
+    def test_get_logical_interconnects_schema(self, mock_get):
+        self.networking.get_li_schema()
+        mock_get.assert_called_once_with(uri['li'] + '/schema')
 
-	@mock.patch.object(connection, 'get')
-	def test_get_logical_interconnects_schema(self, mock_get):
-		self.networking.get_li_schema()
-		mock_get.assert_called_once_with(uri['li'] + '/schema')
+    @mock.patch.object(connection, 'get')
+    def test_get_logical_interconnects_by_id(self, mock_get):
+        id = uuid.uuid4().hex
+        self.networking.get_li_by_id(id)
+        mock_get.assert_called_once_with(uri['li'] + '/' + id)
 
-	@mock.patch.object(connection, 'get')
-	def test_get_logical_interconnects_by_id(self, mock_get):
-		id = uuid.uuid4().hex
-		self.networking.get_li_by_id(id)
-		mock_get.assert_called_once_with(uri['li'] + '/' + id)
+    @mock.patch.object(connection, 'put')
+    def test_correct_li_by_id(self, mock_put):
+        id = uuid.uuid4().hex
+        mock_put.return_value = (None, None)
 
-	@mock.patch.object(connection, 'put')
-	def test_correct_li_by_id(self, mock_put):
-		id = uuid.uuid4().hex
-		mock_put.return_value = (None, None)
+        # passing blocking as False because we just want to test the uri.
+        self.networking.correct_li_by_id(id, blocking=False)
+        correct_li_uri = uri['li'] + '/{id}/compliance'
+        mock_put.assert_called_once_with(correct_li_uri.format(id=id), {})
 
-		# passing blocking as False because we just want to test the uri.
-		self.networking.correct_li_by_id(id, blocking=False)
-		correct_li_uri = uri['li'] + '/{id}/compliance'
-		mock_put.assert_called_once_with(correct_li_uri.format(id=id), {})
-
-	@mock.patch.object(connection, 'put')
-	def test_update_ethernet_interconnected_settings(self, mock_put):
-		id = uuid.uuid4().hex
-		mock_put.return_value = (None, None)
-		settings_test = {"interconnectType": "Ethernet",
+    @mock.patch.object(connection, 'put')
+    def test_update_ethernet_interconnected_settings(self, mock_put):
+        id = uuid.uuid4().hex
+        mock_put.return_value = (None, None)
+        settings_test = {"interconnectType": "Ethernet",
                          "igmpIdleTimeoutInterval": 200,
                          "macRefreshInterval": 10,
                          "name": "ES-882901476",
@@ -185,20 +184,55 @@ class NetworkingTest(unittest.TestCase):
                          "type": "EthernetInterconnectSettingsV3",
                          "id": "9b1380ee-a0bb-4388-af35-2c5a05e84c47"}
 
-		# passing blocking as False because we just want to test the uri.
-		self.networking.update_ethernet_interconnected_settings(
-			id, settings_test, blocking=False)
-		correct_li_uri = uri['li'] + '/{id}/ethernetSettings'
-		mock_put.assert_called_once_with(correct_li_uri.format(id=id),
-			                             settings_test)
+        # passing blocking as False because we just want to test the uri.
+        self.networking.update_ethernet_interconnected_settings(
+            id, settings_test, blocking=False)
+        correct_li_uri = uri['li'] + '/{id}/ethernetSettings'
+        mock_put.assert_called_once_with(correct_li_uri.format(id=id),
+                                         settings_test)
 
-	@mock.patch.object(connection, 'get')
-	def test_get_logical_interconnect_firmware(self, mock_get):
-		id = uuid.uuid4().hex
-		self.networking.get_li_firmware(id)
+    @mock.patch.object(connection, 'get')
+    def test_get_logical_interconnect_firmware(self, mock_get):
+        id = uuid.uuid4().hex
+        self.networking.get_li_firmware(id)
 
-		li_firmware_uri = uri['li'] + '/{id}/firmware'
-		mock_get.assert_called_once_with(li_firmware_uri.format(id=id))
+        li_firmware_uri = uri['li'] + '/{id}/firmware'
+        mock_get.assert_called_once_with(li_firmware_uri.format(id=id))
+
+    @mock.patch.object(connection, 'post')
+    def test_create_lig(self, mock_post):
+        logical_ig = [uuid.uuid4().hex, uuid.uuid4().hex]
+        mock_post.return_value = (None, None)
+
+        # passing blocking as False because we just want to test the uri.
+        self.networking.create_lig(logical_ig, blocking=False)
+
+        mock_post.assert_called_once_with(uri['lig'], logical_ig)
+
+    @mock.patch.object(connection, 'put')
+    def test_update_lig(self, mock_put):
+        logical_ig = {uuid.uuid4().hex: uuid.uuid4().hex}
+        mock_put.return_value = (None, None)
+
+        logical_ig['uri'] = uri['lig']
+
+        # passing blocking as False because we just want to test the uri.
+        self.networking.update_lig(logical_ig, blocking=False)
+
+        mock_put.assert_called_once_with(uri['lig'], logical_ig)
+
+    @mock.patch.object(connection, 'delete')
+    def test_delete_lig(self, mock_delete):
+        logical_ig = {uuid.uuid4().hex: uuid.uuid4().hex}
+        mock_delete.return_value = (None, None)
+
+        logical_ig['uri'] = uri['lig']
+
+        # passing blocking as False because we just want to test the uri.
+        self.networking.delete_lig(logical_ig, blocking=False)
+
+        mock_delete.assert_called_once_with(uri['lig'])
+
 
 if __name__ == '__main__':
-	unittest.main()
+    unittest.main()


### PR DESCRIPTION
Created the tests: test_create_lig, test_update_lig, test_delete_lig
This was the only file in the project that used tabs instead of spaces. Changed to spaces to standardize according to PEP8.