### PR TITLE
TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - 2.7
+install:
+  - touch hpOneView/test/__init__.py hpOneView/test/unit/__init__.py
+  - pip install tox
+script:
+  - tox -- --exit-zero --statistics --count

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/HewlettPackard/python-hpOneView.svg?branch=master)](https://travis-ci.org/HewlettPackard/python-hpOneView)
+
 hpOneView
 =========
 

--- a/hpOneView/test/unit/test_profile.py
+++ b/hpOneView/test/unit/test_profile.py
@@ -146,7 +146,7 @@ class ProfilesTest(unittest.TestCase):
         mock_open.return_value = mock_file
         bios = self.profile.make_bios_dict(filename)
         self.assertIsNotNone(bios)
-        self.assertEquals({'manageBios': True, 'overriddenSettings': [{'value': '2', 'id': '134'}]}, bios)
+        self.assertEqual({'manageBios': True, 'overriddenSettings': [{'value': '2', 'id': '134'}]}, bios)
 
     @mock.patch(mock_builtin('open'))
     def test_make_bios_with_defaukt_options(self, mock_open):
@@ -156,7 +156,7 @@ class ProfilesTest(unittest.TestCase):
         mock_open.return_value = mock_file
         bios = self.profile.make_bios_dict(filename)
         self.assertIsNotNone(bios)
-        self.assertEquals({'manageBios': True, 'overriddenSettings': [{'id': '134'}]}, bios)
+        self.assertEqual({'manageBios': True, 'overriddenSettings': [{'id': '134'}]}, bios)
 
     @mock.patch(mock_builtin('open'))
     def test_make_bios_invalid_json(self, mock_open):

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 
 [tox]
-envlist = py27, py34, py27-flake8, py27-coverage
+envlist = py27, py34, py27-coverage, py27-flake8
 skip_missing_interpreters = true
 
 [flake8]


### PR DESCRIPTION
We are adding the configuration to run the build on Travis CI. 
After the pull-request is accepted, we will be able to add the repository to be built by https://travis-ci.org

This change includes:

- .travis.yml: Configuration file
- README.md: Display the build status from HewlettPackard/python-hpOneView
- Minor fixes on test_profile.py: assertEquals is deprecated, failing the build with Python 3.4.

Since we have some pep8/pylint issues, we are displaying those errors/warning on the travis console but exiting with zero to not break the build. We are going to improve this error handling later.

You can check the results from my fork here: https://travis-ci.org/marikrg/python-hpOneView/pull_requests.