### PR TITLE
Replaced 'print() +  sys.exit()' with Exceptions

### DIFF
--- a/hpOneView/servers.py
+++ b/hpOneView/servers.py
@@ -339,6 +339,10 @@ class servers(object):
                                        serialNumberType, serverHardwareTypeUri,
                                        serverHardwareUri,
                                        serverProfileTemplateUri, uuid, wwnType)
+
+        # missing required field: enclousure group
+        # E.g.: profile['enclosureGroupUri'] =  "/rest/enclosure-groups/a0f1c07b-f811-4c85-8e38-ac5ec34ea2f4"
+
         task, body = self._con.post(uri['profiles'], profile)
         if profile['firmware'] is None:
             tout = 600


### PR DESCRIPTION
Replaced message displayed with print and followed with sys.exit by Execeptions