### PR TITLE
Add support to get resource by uri on ResourceClient

### DIFF
--- a/examples/fc_networks.py
+++ b/examples/fc_networks.py
@@ -63,6 +63,11 @@ try:
 except HPOneViewException as e:
     print(e.msg['message'])
 
+# Get by Uri
+print("Get a fc-network by uri")
+fc_nets_by_uri = oneview_client.fc_networks.get(fc_network['uri'])
+pprint(fc_nets_by_uri)
+
 # Delete the created network
 oneview_client.fc_networks.delete(fc_network)
 print("Sucessfully deleted fc-network")

--- a/examples/fcoe_networks.py
+++ b/examples/fcoe_networks.py
@@ -18,7 +18,6 @@ options = {
     "name": "OneViewSDK Test FCoE Network",
     "vlanId": "201",
     "connectionTemplateUri": None,
-    "type": "fcoe-network",
 }
 oneview_client = OneViewClient(config)
 
@@ -38,31 +37,36 @@ print("  with attribute {'status': %s}" % fcoe_network['status'])
 
 # Get all, with defaults
 print("Get all fcoe-networks")
-fc_nets = oneview_client.fcoe_networks.get_all()
-pprint(fc_nets)
+fcoe_nets = oneview_client.fcoe_networks.get_all()
+pprint(fcoe_nets)
 
 # Filter by name
 print("Get all fcoe-networks filtering by name")
-fc_nets_filtered = oneview_client.fcoe_networks.get_all(filter="\"'name'='OneViewSDK Test FCoE Network'\"")
-pprint(fc_nets_filtered)
+fcoe_nets_filtered = oneview_client.fcoe_networks.get_all(filter="\"'name'='OneViewSDK Test FCoE Network'\"")
+pprint(fcoe_nets_filtered)
 
 # Get all sorting by name descending
 print("Get all fcoe-networks sorting by name")
-fc_nets_sorted = oneview_client.fcoe_networks.get_all(sort='name:descending')
-pprint(fc_nets_sorted)
+fcoe_nets_sorted = oneview_client.fcoe_networks.get_all(sort='name:descending')
+pprint(fcoe_nets_sorted)
 
 # Get the first 10 records
 print("Get the first ten fcoe-networks")
-fc_nets_limited = oneview_client.fcoe_networks.get_all(0, 10)
-pprint(fc_nets_limited)
+fcoe_nets_limited = oneview_client.fcoe_networks.get_all(0, 10)
+pprint(fcoe_nets_limited)
 
 # Get by Id
 try:
     print("Get a fcoe-network by id")
-    fc_nets_byid = oneview_client.fcoe_networks.get('452cf2a8-e5a0-4b9c-9961-0dc6deb80d01')
-    pprint(fc_nets_byid)
+    fcoe_nets_byid = oneview_client.fcoe_networks.get('452cf2a8-e5a0-4b9c-9961-0dc6deb80d01')
+    pprint(fcoe_nets_byid)
 except HPOneViewException as e:
     print(e.msg['message'])
+
+# Get by Uri
+print("Get a fcoe-network by uri")
+fcoe_nets_by_uri = oneview_client.fcoe_networks.get(fcoe_network['uri'])
+pprint(fcoe_nets_by_uri)
 
 # Delete the created network
 oneview_client.fcoe_networks.delete(fcoe_network)

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -21,10 +21,11 @@
 # THE SOFTWARE.
 ###
 
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
+
 from future import standard_library
 
 standard_library.install_aliases()
@@ -112,11 +113,19 @@ class ResourceClient(object):
     def get_schema(self):
         return self._connection.get(self._uri + '/schema')
 
-    def get(self, id):
-        if not id:
+    def get(self, id_or_uri):
+        """
+        Args:
+            id_or_uri: Could be either the resource id or the resource uri
+        Returns:
+             The requested resource
+        """
+        if not id_or_uri:
             raise ValueError(RESOURCE_CLIENT_INVALID_ID)
+        if "/" in id_or_uri:
+            return self.__get_by_uri(id_or_uri)
 
-        return self._connection.get(self._uri + '/' + id)
+        return self._connection.get(self._uri + '/' + id_or_uri)
 
     def update(self, resource, blocking=True):
         if not resource:
@@ -159,3 +168,9 @@ class ResourceClient(object):
 
         filter = filter = "\"'{0}'='{1}'\"".format(field, value)
         return self.get_all(filter=filter)
+
+    def __get_by_uri(self, uri):
+        if self._uri in uri:
+            return self._connection.get(uri)
+        else:
+            raise HPOneViewUnknownType("Unrecognized URI for this resource")

--- a/hpOneView/test/unit/resources/networking/test_fc_networks.py
+++ b/hpOneView/test/unit/resources/networking/test_fc_networks.py
@@ -21,8 +21,9 @@
 # THE SOFTWARE.
 ###
 
-import mock
 import unittest
+
+import mock
 
 from hpOneView.connection import connection
 from hpOneView.resources.networking.fc_networks import FcNetworks
@@ -30,7 +31,6 @@ from hpOneView.resources.resource import ResourceClient
 
 
 class FcNetworksTest(unittest.TestCase):
-
     def setUp(self):
         self.host = '127.0.0.1'
         self.connection = connection(self.host)
@@ -114,7 +114,6 @@ class FcNetworksTest(unittest.TestCase):
 
     @mock.patch.object(ResourceClient, 'delete')
     def test_delete_called_once(self, mock_delete):
-
         id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
         self._fc_networks.delete(id, force=False, blocking=True)
 
@@ -131,3 +130,10 @@ class FcNetworksTest(unittest.TestCase):
         self._fc_networks.get('3518be0e-17c1-4189-8f81-83f3724f6155')
 
         mock_get.assert_called_once_with('3518be0e-17c1-4189-8f81-83f3724f6155')
+
+    @mock.patch.object(ResourceClient, 'get')
+    def test_get_with_uri_called_once(self, mock_get):
+        uri = '/rest/fc-networks/3518be0e-17c1-4189-8f81-83f3724f6155'
+        self._fc_networks.get(uri)
+
+        mock_get.assert_called_once_with(uri)

--- a/hpOneView/test/unit/resources/networking/test_fcoe_networks.py
+++ b/hpOneView/test/unit/resources/networking/test_fcoe_networks.py
@@ -119,3 +119,10 @@ class FcoeNetworksTest(TestCase):
         self._fcoe_networks.get('3518be0e-17c1-4189-8f81-83f3724f6155')
 
         mock_get.assert_called_once_with('3518be0e-17c1-4189-8f81-83f3724f6155')
+
+    @mock.patch.object(ResourceClient, 'get')
+    def test_get_with_uri_called_once(self, mock_get):
+        uri = '/rest/fcoe-networks/3518be0e-17c1-4189-8f81-83f3724f6155'
+        self._fcoe_networks.get(uri)
+
+        mock_get.assert_called_once_with(uri)


### PR DESCRIPTION
Adding support on core methods for get a resource by uri.
It is usefull because the retrieved resources from OneView does not have an attribute `id`, however has a `uri` attribute that contains the path (with the id) to the resource.