### PR TITLE
Creates a configuration loader to run examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+hpOneView - examples
+====================
+
+To run the examples you must install hpOneView and set PYTHONPATH 
+to root of this project.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,27 @@
-hpOneView - examples
-====================
+hpOneView - Examples
+=====================
 
-To run the examples you must install hpOneView and set PYTHONPATH 
-to root of this project.
+
+You can use example files to see how to use the API and test 
+functionality of individual resources.
+
+
+### Prerequisites
+
+- hpOneView must be installed 
+
+
+### Configuration
+To use a common config for all examples, the file `config-rename.json` 
+should be renamed to `config.json`. Otherwise you can set the connection 
+config inside the example. 
+
+:lock: Tip: Check the file permissions because the password is stored in clear-text.
+
+
+### Running
+
+To run these examples follow the steps:
+
+- enter in the examples folder
+- run `python <example_file>.py`

--- a/examples/config-rename.json
+++ b/examples/config-rename.json
@@ -1,0 +1,8 @@
+{
+  "ip": "172.16.102.59",
+  "credentials": {
+    "userName": "administrator",
+    "authLoginDomain": "",
+    "password": ""
+  }
+}

--- a/examples/config_loader.py
+++ b/examples/config_loader.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+###
+# (C) Copyright (2012-2016) Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+###
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from future import standard_library
+
+standard_library.install_aliases()
+
+import json
+import os
+
+CUR_MODULE_DIR = os.path.dirname(__file__)
+DEFAULT_EXAMPLE_CONFIG_FILE = os.path.join(CUR_MODULE_DIR, 'config.json')
+
+
+def try_load_from_file(config, file_name=None):
+    if not file_name:
+        file_name = DEFAULT_EXAMPLE_CONFIG_FILE
+
+    if not os.path.isfile(file_name):
+        return config
+
+    with open(file_name) as json_data:
+        return json.load(json_data)

--- a/examples/fc_networks.py
+++ b/examples/fc_networks.py
@@ -3,7 +3,7 @@
 from pprint import pprint
 from hpOneView.oneview_client import OneViewClient
 from hpOneView.exceptions import HPOneViewException
-from examples.config_loader import try_load_from_file
+from config_loader import try_load_from_file
 
 config = {
     "ip": "172.16.102.59",

--- a/examples/fc_networks.py
+++ b/examples/fc_networks.py
@@ -3,6 +3,7 @@
 from pprint import pprint
 from hpOneView.oneview_client import OneViewClient
 from hpOneView.exceptions import HPOneViewException
+from examples.config_loader import try_load_from_file
 
 config = {
     "ip": "172.16.102.59",
@@ -19,6 +20,10 @@ options = {
     "autoLoginRedistribution": True,
     "fabricType": "FabricAttach",
 }
+
+# Try load config from a file (if there is a config file)
+config = try_load_from_file(config)
+
 oneview_client = OneViewClient(config)
 
 # Create a FC Network

--- a/examples/fcoe_networks.py
+++ b/examples/fcoe_networks.py
@@ -3,7 +3,7 @@
 from pprint import pprint
 from hpOneView.exceptions import HPOneViewException
 from hpOneView.oneview_client import OneViewClient
-from examples.config_loader import try_load_from_file
+from config_loader import try_load_from_file
 
 config = {
     "ip": "172.16.102.59",

--- a/examples/fcoe_networks.py
+++ b/examples/fcoe_networks.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from pprint import pprint
-
 from hpOneView.exceptions import HPOneViewException
 from hpOneView.oneview_client import OneViewClient
+from examples.config_loader import try_load_from_file
 
 config = {
     "ip": "172.16.102.59",
@@ -20,6 +20,10 @@ options = {
     "connectionTemplateUri": None,
     "type": "fcoe-network",
 }
+
+# Try load config from a file (if there is a config file)
+config = try_load_from_file(config)
+
 oneview_client = OneViewClient(config)
 
 # Create a FC Network


### PR DESCRIPTION
This is useful to run examples with a unique configuration.
It's sill possible to use the example just editing the config setting directly on example source.