### PR TITLE
Rebranding HP to HPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 [![Build Status](https://travis-ci.org/HewlettPackard/python-hpOneView.svg?branch=master)](https://travis-ci.org/HewlettPackard/python-hpOneView)
 
-hpOneView
-=========
+HPE OneView SDK Python
+======================
 
-This library provides a pure Python interface to the HP OneView REST APIs.
+This library provides a pure Python interface to the HPE OneView REST APIs.
 
-HP OneView is a fresh approach to converged infrastructure management, inspired
+HPE OneView is a fresh approach to converged infrastructure management, inspired
 by the way you expect to work, with a single integrated view of your IT
 infrastructure.
 
-The HP OneView Python library depends on the
+The HPE OneView Python library depends on the
 [Python-Future](http://python-future.org/index.htm)  library to provide Python
 2/3 compatibility.  This will be installed automatically if you use the installation
 methods described below.
@@ -46,4 +46,4 @@ Coming soon
 API Implementation
 ------------------
 
-Status listing of the HP OneView REST interfaces that have been implemented in the Python library so far is hosted in the [Wiki section](https://github.com/HewlettPackard/python-hpOneView/wiki/API-Implementation) 
+Status listing of the HPE OneView REST interfaces that have been implemented in the Python library so far is hosted in the [Wiki section](https://github.com/HewlettPackard/python-hpOneView/wiki/API-Implementation) 

--- a/examples/scmb/README
+++ b/examples/scmb/README
@@ -1,62 +1,62 @@
-These sample scripts demonstrate the functionality of connecting HP OneView with
-external applications. Specifically, this example generate tickets in HP Service
-Manager based on critical alerts received from HP OneView's State-Change Message
-Bus and then annotates the alert in HP OneView with the new ticket information
-received from HP Service Manager.
+These sample scripts demonstrate the functionality of connecting HPE OneView with
+external applications. Specifically, this example generate tickets in HPE Service
+Manager based on critical alerts received from HPE OneView's State-Change Message
+Bus and then annotates the alert in HPE OneView with the new ticket information
+received from HPE Service Manager.
 
-In HP OneView the State-Change Message Bus (SCMB) is an interface that uses
+In HPE OneView the State-Change Message Bus (SCMB) is an interface that uses
 asynchronous messaging to notify subscribers of changes to managed resources,
 both logical and physical. For example, you can program applications to receive
 notifications when new server hardware is added to the managed environment or
 when the health status of physical resources changes—without having to
 continuously poll the appliance for status using the REST APIs.
 
-HP OneView resources publish messages to the SCMB when they are created,
+HPE OneView resources publish messages to the SCMB when they are created,
 updated, or deleted. The message content is sent in JSON (JavaScript Object
-Notation) format and includes the resource model. To view the list of HP OneView
-resources that publish messages, see the HP OneView REST API Reference.
+Notation) format and includes the resource model. To view the list of HPE OneView
+resources that publish messages, see the HPE OneView REST API Reference.
 
-Two sample scripts are provided to demonstrate connectivity to the HP OneView
+Two sample scripts are provided to demonstrate connectivity to the HPE OneView
 SCMB. Both of the example scripts use the external AMQP library. The first
 script, scmb.py, receives all SCMB messages in the alerts "resource-category"
 and will output all new, active alerts with a critical severity to the console.
 The second script, ov_to_sm.py, is an extension of the first script. Once a new
-critical alert is received this script will connect to HP Service Manager and
+critical alert is received this script will connect to HPE Service Manager and
 open a new ticket for the critical alert, it then takes the ticket number that
-was just created in HP Service Manager and updates the Alert Notes field in HP
+was just created in HPE Service Manager and updates the Alert Notes field in HPE
 OneView with the ticket information.
 
 In order for either of the scripts to register and listen on the SCMB a couple
 of thing need to happen first.
 
-#1. The HP OneView appliance needs to generate a Rabbit MQ keypair. This does
-not happen by default and must be done ONE TIME for the running HP OneView
+#1. The HPE OneView appliance needs to generate a Rabbit MQ keypair. This does
+not happen by default and must be done ONE TIME for the running HPE OneView
 appliance. If either of the example scripts is run with the “-g” argument it
 will request that the keypair is generated and exit. This only needs to be done
-1 time for each HP OneView appliance.
+1 time for each HPE OneView appliance.
 
 #2. The script needs to download a copy of the SSL key and certificate. If
 either of the example scripts is run with the “-d” option it will download the
 required key and certificate. Again, this only needs to be done one time for the
 script.
 
-For Example: assuming, you have a brand new HP OneView appliance invocation
+For Example: assuming, you have a brand new HPE OneView appliance invocation
 would be similar to this:
 
 # Generate the RabbitMQ keypair on the appliance
 
-  ./scmb.py -a [HP OneView Appliance IP] -u Administrator -p MyPass -g
+  ./scmb.py -a [HPE OneView Appliance IP] -u Administrator -p MyPass -g
 
 # Download the SSL key and certificate
 
-  ./scmb.py -a [HP OneView Appliance IP] -u Administrator -p MyPass -d
+  ./scmb.py -a [HPE OneView Appliance IP] -u Administrator -p MyPass -d
 
 Once those two commands have run one time:
 
 The scmby.py scrip can be invoked by:
 
-  ./scmb.py -a [HP OneView Appliance IP] -u Administrator -p MyPass
+  ./scmb.py -a [HPE OneView Appliance IP] -u Administrator -p MyPass
 
 The ov_to_sm.py script can be invoked by:
 
-  ./ov_to_sm.py -a [HP OneView Appliance IP] -u Administrator -p MyPass -sm [SM IP] -x [SM Password]
+  ./ov_to_sm.py -a [HPE OneView Appliance IP] -u Administrator -p MyPass -sm [SM IP] -x [SM Password]

--- a/examples/scmb/ov_to_sm.py
+++ b/examples/scmb/ov_to_sm.py
@@ -113,7 +113,7 @@ def print_alert(uri):
 
 def update_alert(uri, smid):
     alerts = act.get_alerts()
-    notes = 'Case automatically loged in HP Service Manager with ID: ' + smid
+    notes = 'Case automatically loged in HPE Service Manager with ID: ' + smid
     for alert in alerts:
         if alert['uri'] == uri:
             amap = common.make_alertMap_dict(notes, alert['eTag'])
@@ -188,7 +188,7 @@ def callback(channel, msg):
             print('logged SMID: %s with uri: %s resourceUri: %s' %
                   (smid, resource['uri'], body['resourceUri']))
             if ret is True:
-                print('HP OneView Alert Notes Updated')
+                print('HPE OneView Alert Notes Updated')
                 print('------------------------------------------')
                 print_alert(body['resourceUri'])
 
@@ -269,11 +269,11 @@ def main():
     global smhost, smhead, act
     parser = argparse.ArgumentParser(add_help=True, description='Usage')
     parser.add_argument('-a', '--appliance', dest='host', required=True,
-                        help='HP OneView Appliance hostname or IP')
+                        help='HPE OneView Appliance hostname or IP')
     parser.add_argument('-u', '--user', dest='user', required=False,
-                        default='Administrator', help='HP OneView Username')
+                        default='Administrator', help='HPE OneView Username')
     parser.add_argument('-p', '--pass', dest='passwd', required=True,
-                        help='HP OneView Password')
+                        help='HPE OneView Password')
     parser.add_argument('-r', '--route', dest='route', required=False,
                         default='scmb.alerts.#', help='AMQP Routing Key')
     parser.add_argument('-g', '--gen', dest='gen', required=False,

--- a/examples/scmb/scmb.py
+++ b/examples/scmb/scmb.py
@@ -159,11 +159,11 @@ def getRabbitKp(sec):
 def main():
     parser = argparse.ArgumentParser(add_help=True, description='Usage')
     parser.add_argument('-a', '--appliance', dest='host', required=True,
-                        help='HP OneView Appliance hostname or IP')
+                        help='HPE OneView Appliance hostname or IP')
     parser.add_argument('-u', '--user', dest='user', required=False,
-                        default='Administrator', help='HP OneView Username')
+                        default='Administrator', help='HPE OneView Username')
     parser.add_argument('-p', '--pass', dest='passwd', required=True,
-                        help='HP OneView Password')
+                        help='HPE OneView Password')
     parser.add_argument('-r', '--route', dest='route', required=False,
                         default='scmb.alerts.#', help='AMQP Routing Key')
     parser.add_argument('-g', '--gen', dest='gen', required=False,

--- a/examples/scripts/add-datacenter.py
+++ b/examples/scripts/add-datacenter.py
@@ -95,14 +95,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -112,7 +112,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='name',
                         required=True,
                         help='''

--- a/examples/scripts/add-enclosure.py
+++ b/examples/scripts/add-enclosure.py
@@ -121,7 +121,7 @@ def main():
     parser = argparse.ArgumentParser(add_help=True,
                                      formatter_class=argparse.RawTextHelpFormatter,
                                      description='''
-    This example script will import an enclosure into HP OneView as a
+    This example script will import an enclosure into HPE OneView as a
     managed device.  The Onboard Administrator needs to have IP Address
     configured for each module, and a valid Administrator account with a
     password.
@@ -129,14 +129,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -146,7 +146,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-eu', dest='encusr', required=True,
                         help='''
     Administrative username for the c7000 enclosure OA''')
@@ -155,7 +155,7 @@ def main():
     Administrative password for the c7000 enclosure OA''')
     parser.add_argument('-oa', dest='enc', required=True,
                         help='''
-    IP address of the c7000 to import into HP OneView''')
+    IP address of the c7000 to import into HPE OneView''')
     parser.add_argument('-s', dest='spp', required=False,
                         help='''
     SPP Baseline file name. e.g. SPP2013090_2013_0830_30.iso''')

--- a/examples/scripts/add-license.py
+++ b/examples/scripts/add-license.py
@@ -81,14 +81,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -98,10 +98,10 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-f', dest='file', required=True,
                         help='''
-    HP OneView license file 1 key per license file''')
+    HPE OneView license file 1 key per license file''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/add-powerdevice-ipdu.py
+++ b/examples/scripts/add-powerdevice-ipdu.py
@@ -88,14 +88,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -105,7 +105,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-ih', dest='ipdu', required=True,
                         help='''
     Hostname or IP address of the iPDU to add''')

--- a/examples/scripts/add-powerdevice-non-ipdu.py
+++ b/examples/scripts/add-powerdevice-non-ipdu.py
@@ -97,14 +97,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -114,7 +114,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='name',
                         required=True,
                         help='''

--- a/examples/scripts/add-rack.py
+++ b/examples/scripts/add-rack.py
@@ -87,14 +87,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -104,7 +104,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='name',
                         required=True,
                         help='''

--- a/examples/scripts/add-san-manager.py
+++ b/examples/scripts/add-san-manager.py
@@ -85,14 +85,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -102,7 +102,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-sm', dest='sanmgr',
                         required=True,
                         help='''

--- a/examples/scripts/add-server.py
+++ b/examples/scripts/add-server.py
@@ -91,21 +91,21 @@ def main():
                                      description='''
     Import a physical stand-alone rackmount server.
 
-    This exmaple script IS NOT USED to add a Blade Server to the appliance.
+    This example script IS NOT USED to add a Blade Server to the appliance.
     A BL server will automatically be discovered once it inserted into an
     enclosure being managed by the appliance.
 
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -115,7 +115,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-sh', dest='hostname', required=True,
                         help='''
     Hostname or IP address  of the server iLO''')

--- a/examples/scripts/add-spp.py
+++ b/examples/scripts/add-spp.py
@@ -75,19 +75,19 @@ def main():
     parser = argparse.ArgumentParser(add_help=True,
                         formatter_class=argparse.RawTextHelpFormatter,
                                      description='''
-    Upload a SPP file to the HP OneView appliance firmware repository.
+    Upload a SPP file to the HPE OneView appliance firmware repository.
 
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -97,7 +97,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-f', dest='filename', required=True,
                         help='''
     The full path and file name of the SPP file to upload. ''')

--- a/examples/scripts/add-storage-pool.py
+++ b/examples/scripts/add-storage-pool.py
@@ -86,21 +86,21 @@ def main():
     parser = argparse.ArgumentParser(add_help=True,
                         formatter_class=argparse.RawTextHelpFormatter,
                                      description='''
-    Add new Storage Pools (i.e. HP 3PAR Common Provisioning Group [CPG]) for
+    Add new Storage Pools (i.e. HPE 3PAR Common Provisioning Group [CPG]) for
     volumes to be provisioned from.  The Storage System must be imported
     prior to adding Storage Pools.
 
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -110,7 +110,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-sp', dest='pool_name', required=True,
                         help='''
     Storage Pool Name''')

--- a/examples/scripts/add-storage-system.py
+++ b/examples/scripts/add-storage-system.py
@@ -135,21 +135,21 @@ def main():
     mapped to Expected Networks, either a Supported SAN Manager will need to
     be configured, or 3PAR Direct Attach networks will have to exist.
 
-    When adding supported HP 3PAR storage systems, please make sure
-    "startwsapi" has been executed from the HP 3PAR CLI, which enables the
-    HP 3PAR REST API that is required by HP OneView.
+    When adding supported HPE 3PAR storage systems, please make sure
+    "startwsapi" has been executed from the HPE 3PAR CLI, which enables the
+    HPE 3PAR REST API that is required by HPE OneView.
 
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -159,7 +159,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-sh', dest='storage', required=True,
                         help='''
     IP address of the storage system to add''')

--- a/examples/scripts/add-user.py
+++ b/examples/scripts/add-user.py
@@ -106,14 +106,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -123,7 +123,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='name',
                         required=True,
                         help='''

--- a/examples/scripts/add-volume-template.py
+++ b/examples/scripts/add-volume-template.py
@@ -101,14 +101,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -118,7 +118,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='name', required=True,
                         help='''
     Name of the volume template to add''')

--- a/examples/scripts/add-volume.py
+++ b/examples/scripts/add-volume.py
@@ -97,14 +97,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -114,7 +114,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='name',
                         required=True,
                         help='''

--- a/examples/scripts/clear-alerts.py
+++ b/examples/scripts/clear-alerts.py
@@ -80,14 +80,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -97,7 +97,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/copy-profile.py
+++ b/examples/scripts/copy-profile.py
@@ -275,14 +275,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 EncodedDER) Format''')
@@ -292,7 +292,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='name', required=True,
                         help='''
     Name of the source server profile''')
@@ -312,7 +312,7 @@ def main():
 
     . Hostname or IP address of the stand-alone server iLO
     . Server Hardware name of a server than has already been imported
-      into HP OneView and is listed under Server Hardware
+      into HPE OneView and is listed under Server Hardware
     . "UNASSIGNED" for creating an unassigned Server Profile''')
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/define-connection-list.py
+++ b/examples/scripts/define-connection-list.py
@@ -152,14 +152,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -169,7 +169,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='name',
                         required=True,
                         help='''

--- a/examples/scripts/define-enclosure-group.py
+++ b/examples/scripts/define-enclosure-group.py
@@ -88,14 +88,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -105,7 +105,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-l', dest='lname', required=False,
                         help='''
     LIG to assign to enclosure group''')

--- a/examples/scripts/define-ethernet-network.py
+++ b/examples/scripts/define-ethernet-network.py
@@ -96,14 +96,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -113,7 +113,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='network_name', required=True,
                         help='''
     Name of the network''')

--- a/examples/scripts/define-fibrechannel-network.py
+++ b/examples/scripts/define-fibrechannel-network.py
@@ -110,14 +110,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -127,7 +127,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='network_name', required=True,
                         help='''
     Name of the network''')

--- a/examples/scripts/define-logical-interconnect-group.py
+++ b/examples/scripts/define-logical-interconnect-group.py
@@ -157,14 +157,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -174,7 +174,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='logical_interconnect_group_name',
                         required=True,
                         help='''
@@ -318,7 +318,7 @@ def main():
     triggering loop protection on the upstream switch is
     eliminated. When network loop protection is enabled,
     VC interconnects intercept loop detection frames from
-    various switch vendors, such as Cisco and HP
+    various switch vendors, such as Cisco and HPE
     Networking.
 
     When the network loop protection feature is enabled,

--- a/examples/scripts/define-network-set.py
+++ b/examples/scripts/define-network-set.py
@@ -101,14 +101,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -118,7 +118,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='network_set_name', required=True,
                         help='''
     Name of the network set''')

--- a/examples/scripts/define-profile-template.py
+++ b/examples/scripts/define-profile-template.py
@@ -148,14 +148,14 @@ def main():
     Define a server profile template''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -177,7 +177,7 @@ def main():
     parser.add_argument('-sht', dest='server_hwt', required=True,
                         help='''
     Server hardware type is required for defining an unassigned profile. Note
-    the Server Hardware Type must be present in the HP OneView appliance
+    the Server Hardware Type must be present in the HPE OneView appliance
     before it can be used. For example, a single server with the specific server
     hardware type must have been added to OneView for that hardware type to
     be used. The example script get-server-hardware-types.py with the -l
@@ -272,7 +272,7 @@ def main():
         . UEFIOptimized
         . BIOS
 
-    If you select UEFI or UEFI optimized for an HP ProLiant DL Gen9 rack
+    If you select UEFI or UEFI optimized for an HPE ProLiant DL Gen9 rack
     mount server, the remaining boot setting available is the PXE boot policy.
 
     For the UEFI or UEFI optimized boot mode options, the boot mode choice

--- a/examples/scripts/define-profile.py
+++ b/examples/scripts/define-profile.py
@@ -187,14 +187,14 @@ def main():
     Define a server profile''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -204,7 +204,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='name',
                         required=True,
                         help='''
@@ -288,7 +288,7 @@ def main():
         . UEFIOptimized
         . BIOS
 
-    If you select UEFI or UEFI optimized for an HP ProLiant DL Gen9 rack
+    If you select UEFI or UEFI optimized for an HPE ProLiant DL Gen9 rack
     mount server, the remaining boot setting available is the PXE boot policy.
 
     For the UEFI or UEFI optimized boot mode options, the boot mode choice
@@ -378,12 +378,12 @@ def main():
 
         . Hostname or IP address of the stand-alone server iLO
         . Server Hardware name of a server than has already been imported
-          into HP OneView and is listed under Server Hardware
+          into HPE OneView and is listed under Server Hardware
         . "UNASSIGNED" for creating an unassigned Server Profile''')
     parser.add_argument('-sh', dest='server_hwt', required=False,
                         help='''
     Server hardware type is required for defining an unassigned profile. Note
-    the Server Hardware Type must be present in the HP OneView appliance
+    the Server Hardware Type must be present in the HPE OneView appliance
     before it can be used. For example, a single server with the specific server
     hardware type must have been added to OneView for that hardware type to
     be used. The example script get-server-hardware-types.py with the -l

--- a/examples/scripts/define-san-storage-list.py
+++ b/examples/scripts/define-san-storage-list.py
@@ -159,14 +159,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -176,7 +176,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-sl', dest='san_list',
                         required=True,
                         help='''
@@ -200,7 +200,7 @@ def main():
                                  'HPUX11iv2', 'HPUX11iv3', 'SUSE', 'SUSE9',
                                  'Inform'],
                         help='''
-    Specify the Host OS type, which will set the Host OS value when HP OneView
+    Specify the Host OS type, which will set the Host OS value when HPE OneView
     created the Host object on the Storage System. Accepted values:
 
          . CitrixXen = "Citrix Xen Server 5.x/6.x"

--- a/examples/scripts/define-snmp-read-string.py
+++ b/examples/scripts/define-snmp-read-string.py
@@ -76,14 +76,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -93,7 +93,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-s', dest='string', required=True,
                         help='''
     Community Read String''')

--- a/examples/scripts/define-uplink-set.py
+++ b/examples/scripts/define-uplink-set.py
@@ -163,14 +163,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -180,7 +180,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='uplink_set_name', required=True,
                         help='''
     Name of the uplink  set''')

--- a/examples/scripts/define-user-roles.py
+++ b/examples/scripts/define-user-roles.py
@@ -91,14 +91,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -108,7 +108,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-x', dest='upass', required=False,
                         help='''
     New user password''')

--- a/examples/scripts/del-datacenters.py
+++ b/examples/scripts/del-datacenters.py
@@ -86,14 +86,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -103,7 +103,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-f', dest='force', action='store_true',
                         required=False,
                         help='''

--- a/examples/scripts/del-enclosure-group.py
+++ b/examples/scripts/del-enclosure-group.py
@@ -84,14 +84,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -101,7 +101,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-d', dest='delete_all', action='store_true',
                        help='''

--- a/examples/scripts/del-enclosure.py
+++ b/examples/scripts/del-enclosure.py
@@ -93,14 +93,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -110,7 +110,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-d', dest='delete_all', action='store_true',
                        help='''

--- a/examples/scripts/del-logical-interconnect-groups.py
+++ b/examples/scripts/del-logical-interconnect-groups.py
@@ -84,14 +84,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -101,7 +101,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-d', dest='delete_all', action='store_true',
                        help='''

--- a/examples/scripts/del-network-set.py
+++ b/examples/scripts/del-network-set.py
@@ -93,14 +93,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -110,7 +110,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-d', dest='delete_all', action='store_true',
                        help='''

--- a/examples/scripts/del-network.py
+++ b/examples/scripts/del-network.py
@@ -91,14 +91,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -108,7 +108,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-d', dest='delete_all', action='store_true',
                        help='''

--- a/examples/scripts/del-powerdevices.py
+++ b/examples/scripts/del-powerdevices.py
@@ -86,14 +86,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -103,7 +103,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-f', dest='force', action='store_true',
                         required=False,
                         help='''

--- a/examples/scripts/del-profile-template.py
+++ b/examples/scripts/del-profile-template.py
@@ -96,14 +96,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -113,7 +113,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-n', dest='name',
                        help='''

--- a/examples/scripts/del-profile.py
+++ b/examples/scripts/del-profile.py
@@ -109,14 +109,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -126,7 +126,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-f', dest='force', required=False,
                         action='store_true',
                         help='''

--- a/examples/scripts/del-racks.py
+++ b/examples/scripts/del-racks.py
@@ -86,14 +86,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -103,7 +103,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-f', dest='force', action='store_true',
                         required=False,
                         help='''

--- a/examples/scripts/del-san-manager.py
+++ b/examples/scripts/del-san-manager.py
@@ -96,14 +96,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-                        HP OneView Appliance hostname or IP address''')
+                        HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-                        HP OneView Username''')
+                        HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-                        HP OneView Password''')
+                        HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
                         Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -113,7 +113,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-d', dest='delete_all', action='store_true',
                        help='''

--- a/examples/scripts/del-server.py
+++ b/examples/scripts/del-server.py
@@ -85,14 +85,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -102,7 +102,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-f', dest='force', action='store_true',
                         required=False,
                         help='''

--- a/examples/scripts/del-storage-pool.py
+++ b/examples/scripts/del-storage-pool.py
@@ -95,14 +95,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -112,7 +112,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-s', dest='sto_name',
                        help='''

--- a/examples/scripts/del-storage-system.py
+++ b/examples/scripts/del-storage-system.py
@@ -98,14 +98,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -115,7 +115,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-n', dest='name',
                        help='''

--- a/examples/scripts/del-uri.py
+++ b/examples/scripts/del-uri.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-i', dest='uri', required=False,
                         help='''
     URI of the resource to delete''')

--- a/examples/scripts/del-user.py
+++ b/examples/scripts/del-user.py
@@ -82,14 +82,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -99,7 +99,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-d', dest='delete_all', action='store_true',
                         help='''

--- a/examples/scripts/del-volume-template.py
+++ b/examples/scripts/del-volume-template.py
@@ -86,14 +86,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -103,7 +103,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-n', dest='name',
                        help='''

--- a/examples/scripts/del-volume.py
+++ b/examples/scripts/del-volume.py
@@ -87,14 +87,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -104,7 +104,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-n', dest='name',
                        help='''

--- a/examples/scripts/generate-scmb-ca-cert.py
+++ b/examples/scripts/generate-scmb-ca-cert.py
@@ -74,14 +74,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -91,7 +91,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-active-user-sessions.py
+++ b/examples/scripts/get-active-user-sessions.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-address-pool.py
+++ b/examples/scripts/get-address-pool.py
@@ -114,14 +114,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -131,7 +131,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-t', dest='types', required=False,
                         choices=['VMAC', 'VWWN', 'VSN', 'ALL'], default='ALL',
                         help='''

--- a/examples/scripts/get-alerts.py
+++ b/examples/scripts/get-alerts.py
@@ -91,14 +91,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -108,7 +108,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-s', dest='status', required=False,
                         choices=['Active', 'Cleared'],
                         help='''

--- a/examples/scripts/get-appliance-global-settings.py
+++ b/examples/scripts/get-appliance-global-settings.py
@@ -94,14 +94,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -111,7 +111,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='name',
                         required=False,
                         help='''

--- a/examples/scripts/get-appliance-network-interfaces.py
+++ b/examples/scripts/get-appliance-network-interfaces.py
@@ -76,14 +76,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -93,7 +93,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-appliance-startup-progress.py
+++ b/examples/scripts/get-appliance-startup-progress.py
@@ -73,12 +73,12 @@ def main():
     parser = argparse.ArgumentParser(add_help=True,
                         formatter_class=argparse.RawTextHelpFormatter,
                                      description='''
-    Display the startup progress of the HP OneView appliance
+    Display the startup progress of the HPE OneView appliance
 
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -88,7 +88,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
 

--- a/examples/scripts/get-audit-logs.py
+++ b/examples/scripts/get-audit-logs.py
@@ -80,14 +80,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -97,7 +97,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-f', dest='filename',

--- a/examples/scripts/get-backup.py
+++ b/examples/scripts/get-backup.py
@@ -78,14 +78,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -95,7 +95,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-bios-options.py
+++ b/examples/scripts/get-bios-options.py
@@ -132,14 +132,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -159,12 +159,12 @@ def main():
 
         . Hostname or IP address of the stand-alone server iLO
         . The "Server Hardware Name" of a server than has already been imported
-          into HP OneView and is listed under Server Hardware''')
+          into HPE OneView and is listed under Server Hardware''')
     group.add_argument('-sh', dest='server_hwt',
                         help='''
     Server hardware type is required for defining BIOS options without
     specifying a specific server identification. The Server Hardware Type must
-    be present in the HP OneView appliance before it can be used. For example,
+    be present in the HPE OneView appliance before it can be used. For example,
     a single server with the specific server hardware type must have been added
     to OneView for that hardware type to be used. The example script
     get-server-hardware-types.py with the -l argument can be used to get a list

--- a/examples/scripts/get-category-actions.py
+++ b/examples/scripts/get-category-actions.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-connectible-volume-templates.py
+++ b/examples/scripts/get-connectible-volume-templates.py
@@ -74,14 +74,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -91,7 +91,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-connections.py
+++ b/examples/scripts/get-connections.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-datacenters.py
+++ b/examples/scripts/get-datacenters.py
@@ -76,14 +76,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -93,7 +93,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-device-managers.py
+++ b/examples/scripts/get-device-managers.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-domains.py
+++ b/examples/scripts/get-domains.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-enclosure-group.py
+++ b/examples/scripts/get-enclosure-group.py
@@ -78,14 +78,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -95,7 +95,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='name',
                         required=False,
                         help='''

--- a/examples/scripts/get-enclosure.py
+++ b/examples/scripts/get-enclosure.py
@@ -129,14 +129,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -146,7 +146,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='name',
                         required=False,
                         help='''

--- a/examples/scripts/get-envconf.py
+++ b/examples/scripts/get-envconf.py
@@ -79,14 +79,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-n', dest='name',
                         required=False,
                         help='''
@@ -101,7 +101,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-eula-status.py
+++ b/examples/scripts/get-eula-status.py
@@ -59,14 +59,14 @@ def main():
                         formatter_class=argparse.RawTextHelpFormatter,
                                      description='''
     Retrieve EULA (End User License Agreement) status from the
-    HP OneView appliance. The output is "True" if the appliance requires
+    HPE OneView appliance. The output is "True" if the appliance requires
     the EULA to be accepted and "False" if the EULA has already been
     accepted.
 
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -76,7 +76,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
 

--- a/examples/scripts/get-health-status.py
+++ b/examples/scripts/get-health-status.py
@@ -82,20 +82,20 @@ def main():
     parser = argparse.ArgumentParser(add_help=True,
                         formatter_class=argparse.RawTextHelpFormatter,
                                      description='''
-    Display the HP OneView appliance health status. This
+    Display the HPE OneView appliance health status. This
     includes CPU, Memory and Disk Space.
 
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -105,7 +105,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-interconnect-types.py
+++ b/examples/scripts/get-interconnect-types.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-interconnects.py
+++ b/examples/scripts/get-interconnects.py
@@ -117,14 +117,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -134,7 +134,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='name',
                         required=False,
                         help='''

--- a/examples/scripts/get-license.py
+++ b/examples/scripts/get-license.py
@@ -121,14 +121,14 @@ def main():
                                      Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -138,7 +138,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-r', dest='report',
                         required=False, action='store_true',
                         help='''

--- a/examples/scripts/get-logical-interconnect-groups.py
+++ b/examples/scripts/get-logical-interconnect-groups.py
@@ -80,14 +80,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -97,7 +97,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-n', dest='name', required=False,
                         action='store_true',
                         help='''

--- a/examples/scripts/get-logical-interconnect-uplink-sets.py
+++ b/examples/scripts/get-logical-interconnect-uplink-sets.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-logical-interconnect.py
+++ b/examples/scripts/get-logical-interconnect.py
@@ -108,14 +108,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -125,7 +125,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-r', dest='report',
                         required=False, action='store_true',
                         help='''

--- a/examples/scripts/get-managed-sans.py
+++ b/examples/scripts/get-managed-sans.py
@@ -76,14 +76,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -93,7 +93,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-network-set.py
+++ b/examples/scripts/get-network-set.py
@@ -76,14 +76,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -93,7 +93,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-networks.py
+++ b/examples/scripts/get-networks.py
@@ -161,14 +161,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -178,7 +178,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-t', dest='ntype', required=False,
                         choices=['Ethernet', 'FC'],
                         help='''

--- a/examples/scripts/get-node-status.py
+++ b/examples/scripts/get-node-status.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-node-version.py
+++ b/examples/scripts/get-node-version.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-powerdevices.py
+++ b/examples/scripts/get-powerdevices.py
@@ -76,14 +76,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -93,7 +93,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-profile-connections.py
+++ b/examples/scripts/get-profile-connections.py
@@ -98,14 +98,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -115,7 +115,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-r', dest='report',
                         required=False, action='store_true',
                         help='''

--- a/examples/scripts/get-profile-templates.py
+++ b/examples/scripts/get-profile-templates.py
@@ -87,14 +87,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -104,7 +104,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-n', dest='name',
                        help='''

--- a/examples/scripts/get-profiles.py
+++ b/examples/scripts/get-profiles.py
@@ -87,14 +87,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -104,7 +104,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-n', dest='name',
                        help='''

--- a/examples/scripts/get-providers.py
+++ b/examples/scripts/get-providers.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-racks.py
+++ b/examples/scripts/get-racks.py
@@ -76,14 +76,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -93,7 +93,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-restores.py
+++ b/examples/scripts/get-restores.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-role-category-actions.py
+++ b/examples/scripts/get-role-category-actions.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-san-manager.py
+++ b/examples/scripts/get-san-manager.py
@@ -76,14 +76,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -93,7 +93,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-san-providers.py
+++ b/examples/scripts/get-san-providers.py
@@ -76,14 +76,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -93,7 +93,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-schema.py
+++ b/examples/scripts/get-schema.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-scmb-keypair.py
+++ b/examples/scripts/get-scmb-keypair.py
@@ -76,20 +76,20 @@ def main():
                         formatter_class=argparse.RawTextHelpFormatter,
                                      description='''
     Download the SCMB (RabbitMq) base-64 encoded certificate and keypair from
-    the HP OneView appliance. NOTE: This requires that the keypair has been
+    the HPE OneView appliance. NOTE: This requires that the keypair has been
     previously generated (generate-scmb-ca-cert.py).
 
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -99,7 +99,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-server-hardware-types.py
+++ b/examples/scripts/get-server-hardware-types.py
@@ -79,14 +79,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -96,7 +96,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-l', dest='lst', required=False,
                         action='store_true',
                         help='''

--- a/examples/scripts/get-serverbios.py
+++ b/examples/scripts/get-serverbios.py
@@ -79,14 +79,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-n', dest='name',
                         required=False,
                         help='''
@@ -101,7 +101,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-servers.py
+++ b/examples/scripts/get-servers.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-single-server-hardware-type.py
+++ b/examples/scripts/get-single-server-hardware-type.py
@@ -79,14 +79,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-n', dest='name',
                         required=False,
                         help='''
@@ -101,7 +101,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-snmp-read-string.py
+++ b/examples/scripts/get-snmp-read-string.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-spp.py
+++ b/examples/scripts/get-spp.py
@@ -83,14 +83,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -100,7 +100,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-storage-pool.py
+++ b/examples/scripts/get-storage-pool.py
@@ -96,14 +96,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -113,7 +113,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-s', dest='sto_name',
                        help='''

--- a/examples/scripts/get-storage-systems.py
+++ b/examples/scripts/get-storage-systems.py
@@ -96,14 +96,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -113,7 +113,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-n', dest='name',
                        help='''

--- a/examples/scripts/get-storage-volume-template-policy.py
+++ b/examples/scripts/get-storage-volume-template-policy.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-support-dump.py
+++ b/examples/scripts/get-support-dump.py
@@ -72,19 +72,19 @@ def main():
     parser = argparse.ArgumentParser(add_help=True,
                         formatter_class=argparse.RawTextHelpFormatter,
                                      description='''
-    Generate and download a support dump from the HP OneView Appliance
+    Generate and download a support dump from the HPE OneView Appliance
 
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -94,7 +94,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-tasks.py
+++ b/examples/scripts/get-tasks.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-trap-dest.py
+++ b/examples/scripts/get-trap-dest.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-unmanaged-devices.py
+++ b/examples/scripts/get-unmanaged-devices.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-uri.py
+++ b/examples/scripts/get-uri.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-i', dest='uri', required=False,
                         help='''
     URI of the resource to get''')

--- a/examples/scripts/get-users.py
+++ b/examples/scripts/get-users.py
@@ -75,14 +75,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-utilization.py
+++ b/examples/scripts/get-utilization.py
@@ -79,14 +79,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-n', dest='name',
                         required=False,
                         help='''
@@ -101,7 +101,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/get-volume-template.py
+++ b/examples/scripts/get-volume-template.py
@@ -88,14 +88,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -105,7 +105,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-n', dest='name',
                        help='''

--- a/examples/scripts/get-volume.py
+++ b/examples/scripts/get-volume.py
@@ -88,14 +88,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -105,7 +105,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-n', dest='name',
                        help='''

--- a/examples/scripts/get-xapi.py
+++ b/examples/scripts/get-xapi.py
@@ -76,14 +76,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -93,7 +93,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
 
     args = parser.parse_args()
     credential = {'authLoginDomain': args.domain.upper(), 'userName': args.user, 'password': args.passwd}

--- a/examples/scripts/install-appliance-fw.py
+++ b/examples/scripts/install-appliance-fw.py
@@ -91,14 +91,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -108,7 +108,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-f', dest='file',
                        help='''

--- a/examples/scripts/restore-backup.py
+++ b/examples/scripts/restore-backup.py
@@ -84,19 +84,19 @@ def main():
     parser = argparse.ArgumentParser(add_help=True,
                         formatter_class=argparse.RawTextHelpFormatter,
                                      description='''
-    Upload and restore a HP OneView backup file
+    Upload and restore a HPE OneView backup file
 
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -106,7 +106,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     parser.add_argument('-f', dest='file', required=True,
                         help='''
     Backup file to restore''')

--- a/examples/scripts/set-serviceaccess.py
+++ b/examples/scripts/set-serviceaccess.py
@@ -80,14 +80,14 @@ def main():
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -97,7 +97,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-e', dest='ena', action='store_true',
                        help='''

--- a/examples/scripts/shutdown.py
+++ b/examples/scripts/shutdown.py
@@ -71,19 +71,19 @@ def main():
     parser = argparse.ArgumentParser(add_help=True,
                         formatter_class=argparse.RawTextHelpFormatter,
                                      description='''
-    Shutdown or Reboot the HP OneView Appliance
+    Shutdown or Reboot the HPE OneView Appliance
 
     Usage: ''')
     parser.add_argument('-a', dest='host', required=True,
                         help='''
-    HP OneView Appliance hostname or IP address''')
+    HPE OneView Appliance hostname or IP address''')
     parser.add_argument('-u', dest='user', required=False,
                         default='Administrator',
                         help='''
-    HP OneView Username''')
+    HPE OneView Username''')
     parser.add_argument('-p', dest='passwd', required=True,
                         help='''
-    HP OneView Password''')
+    HPE OneView Password''')
     parser.add_argument('-c', dest='cert', required=False,
                         help='''
     Trusted SSL Certificate Bundle in PEM (Base64 Encoded DER) Format''')
@@ -93,7 +93,7 @@ def main():
     parser.add_argument('-j', dest='domain', required=False,
                         default='Local',
                         help='''
-    HP OneView Authorized Login Domain''')
+    HPE OneView Authorized Login Domain''')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-r', dest='reboot', action='store_true',
                        help='''

--- a/hpOneView/__init__.py
+++ b/hpOneView/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-HP OneView Library
+HPE OneView Library
 ~~~~~~~~~~~~~~~~~~~~~
 
-hpOneView is a library for interfacing with HP OneView Management Appliance.
+hpOneView is a library for interfacing with HPE OneView Management Appliance.
 """
 from __future__ import unicode_literals
 from __future__ import print_function
@@ -69,11 +69,11 @@ from hpOneView.uncategorized import *
 def main():
     parser = argparse.ArgumentParser(add_help=True, description='Usage')
     parser.add_argument('-a', '--appliance', dest='host', required=True,
-                        help='HP OneView Appliance hostname or IP')
+                        help='HPE OneView Appliance hostname or IP')
     parser.add_argument('-u', '--user', dest='user', required=True,
-                        help='HP OneView Username')
+                        help='HPE OneView Username')
     parser.add_argument('-p', '--pass', dest='passwd', required=True,
-                        help='HP OneView Password')
+                        help='HPE OneView Password')
     parser.add_argument('-c', '--certificate', dest='cert', required=False,
                         help='Trusted SSL Certificate Bundle in PEM '
                         '(Base64 Encoded DER) Format')

--- a/hpOneView/activity.py
+++ b/hpOneView/activity.py
@@ -4,7 +4,7 @@
 activity.py
 ~~~~~~~~~~~~
 
-This module implements the Activity HP OneView REST API
+This module implements the Activity HPE OneView REST API
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/hpOneView/common.py
+++ b/hpOneView/common.py
@@ -1094,12 +1094,12 @@ def make_FirmwareSettingsV3(firmwareUri,
         firmwareInstallType:
             FirmwareAndOSDrivers:
                 Updates the firmware and OS drivers without powering down the
-                server hardware using HP Smart Update Tools.
+                server hardware using HPE Smart Update Tools.
             FirmwareOnly:
                  Updates the firmware without powering down the server hardware
-                 using using HP Smart Update Tools.
+                 using using HPE Smart Update Tools.
             FirmwareOnlyOfflineMode:
-                Manages the firmware through HP OneView. Selecting this option
+                Manages the firmware through HPE OneView. Selecting this option
                 requires the server hardware to be powered down.
         manageFirmware:
             Indicates that the server firmware is configured using the server

--- a/hpOneView/exceptions.py
+++ b/hpOneView/exceptions.py
@@ -4,7 +4,7 @@
 exceptions.py
 ~~~~~~~~~~~~
 
-This module implements exceptions HP OneView REST API
+This module implements exceptions HPE OneView REST API
 """
 from __future__ import unicode_literals
 from __future__ import print_function

--- a/hpOneView/facilities.py
+++ b/hpOneView/facilities.py
@@ -4,7 +4,7 @@
 facilities.py
 ~~~~~~~~~~~~
 
-This module implements settings HP OneView REST API
+This module implements settings HPE OneView REST API
 """
 from __future__ import absolute_import
 from __future__ import division
@@ -17,7 +17,7 @@ standard_library.install_aliases()
 
 __title__ = 'facilities'
 __version__ = '0.0.1'
-__copyright__ = '(C) Copyright 2012-2015 Hewlett-Packard Development ' \
+__copyright__ = '(C) Copyright 2012-2015 Hewlett Packard Enterprise' \
                 ' Development LP'
 __license__ = 'MIT'
 __status__ = 'Development'

--- a/hpOneView/fcsans.py
+++ b/hpOneView/fcsans.py
@@ -4,7 +4,7 @@
 fcsans.py
 ~~~~~~~~~~~~
 
-This module implements settings HP OneView REST API
+This module implements settings HPE OneView REST API
 """
 from __future__ import unicode_literals
 from __future__ import print_function

--- a/hpOneView/networking.py
+++ b/hpOneView/networking.py
@@ -4,7 +4,7 @@
 networking.py
 ~~~~~~~~~~~~
 
-This module implements Settings HP OneView REST API
+This module implements Settings HPE OneView REST API
 """
 from __future__ import absolute_import
 from __future__ import division
@@ -140,7 +140,7 @@ class networking(object):
                 self.get_lis(filter='?start=0&count=10')
 
                 For more options, see the Common Parameters session from
-                the HP OneView API reference.
+                the HPE OneView API reference.
         Returns: dict
         """
         return get_members(self._con.get(uri['li'] + filter))
@@ -549,7 +549,7 @@ class networking(object):
                 self.get_logical_downlinks(filter='?start=0&count=10')
 
                 For more options, see the Common Parameters session from
-                the HP OneView API reference.
+                the HPE OneView API reference.
         Returns: dict
         """
         downlinks_uri = uri['ld'] + filter
@@ -580,7 +580,7 @@ class networking(object):
                                                             '?start=0&count=10')
 
                 For more options, see the Common Parameters session from
-                the HP OneView API reference.
+                the HPE OneView API reference.
         Returns: dict
         """
         downlinks_uri = uri['ld'] + '/withoutEthernet' + filter

--- a/hpOneView/oneview_client.py
+++ b/hpOneView/oneview_client.py
@@ -24,7 +24,7 @@
 oneview_client.py
 ~~~~~~~~~~~~
 
-This module implements a common client for HP OneView REST API
+This module implements a common client for HPE OneView REST API
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/hpOneView/search.py
+++ b/hpOneView/search.py
@@ -4,7 +4,7 @@
 search.py
 ~~~~~~~~~~~~
 
-This module implements search HP OneView REST API
+This module implements search HPE OneView REST API
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/hpOneView/security.py
+++ b/hpOneView/security.py
@@ -4,7 +4,7 @@
 security.py
 ~~~~~~~~~~~~
 
-This module implements Settings HP OneView REST API
+This module implements Settings HPE OneView REST API
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/hpOneView/servers.py
+++ b/hpOneView/servers.py
@@ -4,7 +4,7 @@
 servers.py
 ~~~~~~~~~~~~
 
-This module implements servers HP OneView REST API
+This module implements servers HPE OneView REST API
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/hpOneView/settings.py
+++ b/hpOneView/settings.py
@@ -4,7 +4,7 @@
 settings.py
 ~~~~~~~~~~~~
 
-This module implements settings HP OneView REST API
+This module implements settings HPE OneView REST API
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/hpOneView/storage.py
+++ b/hpOneView/storage.py
@@ -4,7 +4,7 @@
 storage.py
 ~~~~~~~~~~~~
 
-This module implements settings HP OneView REST API
+This module implements settings HPE OneView REST API
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/hpOneView/uncategorized.py
+++ b/hpOneView/uncategorized.py
@@ -4,7 +4,7 @@
 uncategorized.py
 ~~~~~~~~~~~~
 
-This module implements settings HP OneView REST API
+This module implements settings HPE OneView REST API
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ from setuptools import setup
 
 setup(name='hpOneView',
       version='0.1',
-      description='HP OneView Python Library',
-      url='http://hp.com/go/OneViewCommunity',
+      description='HPE OneView Python Library',
+      url='http://www.hpe.com/info/oneviewcommunity',
       author='Hewlett Packard Enterprise Development LP',
       license='MIT',
       packages=['hpOneView', 'hpOneView/resources', 'hpOneView/resources/networking', 'hpOneView/resources/data_services'],


### PR DESCRIPTION
Below is a summary of replaced text:

Location | Found | Replaced
----------- | -------- | ------------
README.md | HP OneView | HPE OneView
examples\scmb\readme | HP OneView, HP Service Manager | HPE OneView, HPE Service Manager
setup.py | HP OneView | HPE OneView
setup.py | http://hp.com/go/OneViewCommunity | http://www.hpe.com/info/oneviewcommunity
hpOneView\facilities.py | Hewlett-Packard Development Development LP | Hewlett Packard Enterprise Development LP
hpOneView\common.py (Code comment) | HP Smart Update Tools | HPE Smart Update Tools
514 occurrences in py files (string constants + code comment) | HP OneView | HPE OneView
Examples | HP ProLiant DL Gen9 | HPE ProLiant DL Gen9
Examples | HP 3PAR | HPE 3PAR
Examples | HP Networking | HPE Networking

