### PR TITLE
Fix: User values for an endpoint are always overwritten by default values

### DIFF
--- a/hpOneView/resources/networking/fc_networks.py
+++ b/hpOneView/resources/networking/fc_networks.py
@@ -118,8 +118,9 @@ class FcNetworks(object):
         Returns: Created resource. When blocking=False, returns the task.
 
         """
-        resource.update(self.__default_values)
-        return self._client.create(resource, blocking)
+        data = self.__default_values.copy()
+        data.update(resource)
+        return self._client.create(data, blocking)
 
     def update(self, resource, blocking=True):
         """
@@ -133,8 +134,9 @@ class FcNetworks(object):
         Returns: Updated resource. When blocking=False, returns the task.
 
         """
-        resource.update(self.__default_values)
-        return self._client.update(resource, blocking)
+        data = self.__default_values.copy()
+        data.update(resource)
+        return self._client.update(data, blocking)
 
     def get_by(self, field, value):
         """

--- a/hpOneView/resources/networking/fcoe_networks.py
+++ b/hpOneView/resources/networking/fcoe_networks.py
@@ -112,8 +112,9 @@ class FcoeNetworks(object):
 
         Returns: Created resource. When blocking=False, returns the task.
         """
-        resource.update(self.__default_values)
-        return self._client.create(resource, blocking)
+        data = self.__default_values.copy()
+        data.update(resource)
+        return self._client.create(data, blocking)
 
     def update(self, resource, blocking=True):
         """
@@ -126,8 +127,9 @@ class FcoeNetworks(object):
 
         Returns: Updated resource. When blocking=False, returns the task.
         """
-        resource.update(self.__default_values)
-        return self._client.update(resource, blocking)
+        data = self.__default_values.copy()
+        data.update(resource)
+        return self._client.update(data, blocking)
 
     def get_by(self, field, value):
         """

--- a/hpOneView/test/unit/resources/data_services/test_metric_streaming.py
+++ b/hpOneView/test/unit/resources/data_services/test_metric_streaming.py
@@ -57,7 +57,8 @@ class MetricStreamingTest(TestCase):
                 }
             ]
         }
+        configuration_rest_call = configuration.copy()
         mock_update.return_value = configuration
 
         self._metrics.update_configuration(configuration)
-        mock_update.assert_called_once_with(configuration, "/rest/metrics/configuration")
+        mock_update.assert_called_once_with(configuration_rest_call, "/rest/metrics/configuration")

--- a/hpOneView/test/unit/resources/networking/test_fc_networks.py
+++ b/hpOneView/test/unit/resources/networking/test_fc_networks.py
@@ -49,15 +49,16 @@ class FcNetworksTest(unittest.TestCase):
     def test_create_should_use_given_values(self, mock_create):
         resource = {
             'name': 'OneViewSDK Test FC Network',
-            'autoLoginRedistribution': False,
+            'autoLoginRedistribution': True,
             'type': 'fc-networkV2',
-            'linkStabilityTime': 30,
+            'linkStabilityTime': 20,
             'fabricType': None,
         }
+        resource_rest_call = resource.copy()
         mock_create.return_value = {}
 
         self._fc_networks.create(resource, False)
-        mock_create.assert_called_once_with(resource, False)
+        mock_create.assert_called_once_with(resource_rest_call, False)
 
     @mock.patch.object(ResourceClient, 'create')
     def test_create_should_use_default_values(self, mock_create):
@@ -83,14 +84,15 @@ class FcNetworksTest(unittest.TestCase):
             'name': 'OneViewSDK Test FC Network',
             'autoLoginRedistribution': False,
             'type': 'fc-networkV2',
-            'linkStabilityTime': 30,
+            'linkStabilityTime': 20,
             'fabricType': None,
             'uri': 'a_uri',
         }
+        resource_rest_call = resource.copy()
         mock_update.return_value = {}
 
         self._fc_networks.update(resource, False)
-        mock_update.assert_called_once_with(resource, False)
+        mock_update.assert_called_once_with(resource_rest_call, False)
 
     @mock.patch.object(ResourceClient, 'update')
     def test_update_should_use_default_values(self, mock_update):

--- a/hpOneView/test/unit/resources/networking/test_fcoe_networks.py
+++ b/hpOneView/test/unit/resources/networking/test_fcoe_networks.py
@@ -53,10 +53,11 @@ class FcoeNetworksTest(TestCase):
             'connectionTemplateUri': None,
             'type': 'fcoe-networkV2',
         }
+        resource_rest_call = resource.copy()
         mock_create.return_value = {}
 
         self._fcoe_networks.create(resource, False)
-        mock_create.assert_called_once_with(resource, False)
+        mock_create.assert_called_once_with(resource_rest_call, False)
 
     @mock.patch.object(ResourceClient, 'create')
     def test_create_should_use_default_values(self, mock_create):
@@ -81,10 +82,11 @@ class FcoeNetworksTest(TestCase):
             'connectionTemplateUri': None,
             'type': 'fcoe-networkV2',
         }
+        resource_rest_call = resource.copy()
         mock_update.return_value = {}
 
         self._fcoe_networks.update(resource, False)
-        mock_update.assert_called_once_with(resource, False)
+        mock_update.assert_called_once_with(resource_rest_call, False)
 
     @mock.patch.object(ResourceClient, 'update')
     def test_update_should_use_default_values(self, mock_update):


### PR DESCRIPTION
User defined values for an endpoint are always overwritten by the resource default values