### PR TITLE
Remove "authLoginDomain" from examples to keep it simple

### DIFF
--- a/examples/connection_templates.py
+++ b/examples/connection_templates.py
@@ -29,7 +29,6 @@ from config_loader import try_load_from_file
 config = {
     "ip": "",
     "credentials": {
-        "authLoginDomain": "",
         "userName": "administrator",
         "password": ""
     }

--- a/examples/enclosures.py
+++ b/examples/enclosures.py
@@ -29,7 +29,6 @@ from config_loader import try_load_from_file
 config = {
     "ip": "172.16.102.59",
     "credentials": {
-        "authLoginDomain": "",
         "userName": "administrator",
         "password": ""
     }

--- a/examples/ethernet_networks.py
+++ b/examples/ethernet_networks.py
@@ -29,7 +29,6 @@ from config_loader import try_load_from_file
 config = {
     "ip": "",
     "credentials": {
-        "authLoginDomain": "",
         "userName": "administrator",
         "password": ""
     }

--- a/examples/fabrics.py
+++ b/examples/fabrics.py
@@ -29,7 +29,6 @@ from config_loader import try_load_from_file
 config = {
     "ip": "",
     "credentials": {
-        "authLoginDomain": "",
         "userName": "administrator",
         "password": ""
     }

--- a/examples/fc_networks.py
+++ b/examples/fc_networks.py
@@ -29,7 +29,6 @@ from config_loader import try_load_from_file
 config = {
     "ip": "172.16.102.59",
     "credentials": {
-        "authLoginDomain": "",
         "userName": "administrator",
         "password": ""
     }

--- a/examples/fcoe_networks.py
+++ b/examples/fcoe_networks.py
@@ -29,7 +29,6 @@ from config_loader import try_load_from_file
 config = {
     "ip": "172.16.102.59",
     "credentials": {
-        "authLoginDomain": "",
         "userName": "administrator",
         "password": ""
     }

--- a/examples/interconnects.py
+++ b/examples/interconnects.py
@@ -29,7 +29,6 @@ from config_loader import try_load_from_file
 config = {
     "ip": "172.16.102.59",
     "credentials": {
-        "authLoginDomain": "",
         "userName": "administrator",
         "password": ""
     }

--- a/examples/logical_interconnect_groups.py
+++ b/examples/logical_interconnect_groups.py
@@ -31,7 +31,6 @@ from hpOneView.oneview_client import OneViewClient
 config = {
     "ip": "172.16.102.59",
     "credentials": {
-        "authLoginDomain": "",
         "userName": "administrator",
         "password": ""
     }

--- a/examples/metric_streaming.py
+++ b/examples/metric_streaming.py
@@ -29,7 +29,6 @@ from hpOneView.oneview_client import OneViewClient
 config = {
     "ip": "172.16.102.59",
     "credentials": {
-        "authLoginDomain": "",
         "userName": "administrator",
         "password": ""
     }

--- a/examples/network_sets.py
+++ b/examples/network_sets.py
@@ -29,7 +29,6 @@ from config_loader import try_load_from_file
 config = {
     "ip": "",
     "credentials": {
-        "authLoginDomain": "",
         "userName": "administrator",
         "password": ""
     }

--- a/examples/power_devices.py
+++ b/examples/power_devices.py
@@ -30,7 +30,6 @@ from hpOneView.oneview_client import OneViewClient
 config = {
     "ip": "172.16.102.59",
     "credentials": {
-        "authLoginDomain": "",
         "userName": "administrator",
         "password": ""
     }

--- a/examples/server_hardware.py
+++ b/examples/server_hardware.py
@@ -29,7 +29,6 @@ from config_loader import try_load_from_file
 config = {
     "ip": "172.16.102.59",
     "credentials": {
-        "authLoginDomain": "",
         "userName": "administrator",
         "password": ""
     }

--- a/examples/switch_types.py
+++ b/examples/switch_types.py
@@ -29,7 +29,6 @@ from config_loader import try_load_from_file
 config = {
     "ip": "",
     "credentials": {
-        "authLoginDomain": "",
         "userName": "administrator",
         "password": ""
     }

--- a/examples/switches.py
+++ b/examples/switches.py
@@ -29,7 +29,6 @@ from config_loader import try_load_from_file
 config = {
     "ip": "172.16.102.59",
     "credentials": {
-        "authLoginDomain": "",
         "userName": "administrator",
         "password": ""
     }

--- a/examples/tasks.py
+++ b/examples/tasks.py
@@ -29,7 +29,6 @@ from config_loader import try_load_from_file
 config = {
     "ip": "172.16.102.59",
     "credentials": {
-        "authLoginDomain": "",
         "userName": "administrator",
         "password": ""
     }


### PR DESCRIPTION
This attribute is optional.