### PR TITLE
Changes the Python hashbang

### DIFF
--- a/hpOneView/__init__.py
+++ b/hpOneView/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 HPE OneView Library
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Changes the hashbang from `python3` to `python`, since `python` should be used for scripts that are source compatible with both Python 2 and 3. 