### PR TITLE
Improvements: Enclosure endpoints and examples

### DIFF
--- a/examples/enclosures.py
+++ b/examples/enclosures.py
@@ -53,9 +53,9 @@ print("Added enclosure '%s'.\n  uri = '%s'" % (enclosure['name'], enclosure['uri
 
 # Update the enclosure name
 enclosure_name = enclosure['name'] + "-Updated"
-print("Updates the enclosure to have a name of '%s'" % enclosure_name)
+print("Updating the enclosure to have a name of '%s'" % enclosure_name)
 enclosure = oneview_client.enclosures.patch(enclosure['uri'], 'replace', '/name', enclosure_name)
-print("  Completed.\n  uri = '%s', name = %s" % (enclosure['uri'], enclosure['name']))
+print("  Done.\n  uri = '%s', name = %s" % (enclosure['uri'], enclosure['name']))
 
 # Find the recently added enclosure by name
 enclosure = oneview_client.enclosures.get_by('name', enclosure['name'])[0]
@@ -71,29 +71,21 @@ enclosures = oneview_client.enclosures.get_all()
 for enc in enclosures:
     print('  %s' % enc['name'])
 
-print("Reapply the appliance's configuration on the enclosure")
+print("Reapplying the appliance's configuration on the enclosure")
 try:
     oneview_client.enclosures.update_configuration(enclosure['uri'])
     print("  Done.")
 except HPOneViewException as e:
     print(e.msg['message'])
 
-print("Retrieve environmental configuration data for the enclosure")
+print("Retrieve the environmental configuration data for the enclosure")
 try:
     environmental_configuration = oneview_client.enclosures.get_environmental_configuration(enclosure['uri'])
     print("  Enclosure calibratedMaxPower = %s" % environmental_configuration['calibratedMaxPower'])
 except HPOneViewException as e:
     print("  %s" % e.msg['message'])
 
-print("Set the calibrated max power of the enclosure")
-try:
-    config = {"calibratedMaxPower": 2500}
-    environmental_configuration = oneview_client.enclosures.update_environmental_configuration(enclosure['uri'], config)
-    print("  Enclosure calibratedMaxPower = %s" % environmental_configuration['calibratedMaxPower'])
-except HPOneViewException as e:
-    print("  %s" % e.msg['message'])
-
-print("Refresh the enclosure")
+print("Refreshing the enclosure")
 try:
     config = {"refreshState": "RefreshPending"}
     enclosure = oneview_client.enclosures.refresh_state(enclosure['uri'], config)
@@ -108,34 +100,24 @@ try:
 except HPOneViewException as e:
     print("  %s" % e.msg['message'])
 
-print("Builds the SSO (Single Sign-On) URL parameters for the enclosure")
+print("Build the SSO (Single Sign-On) URL parameters for the enclosure")
 try:
     sso_url_parameters = oneview_client.enclosures.get_sso(enclosure['uri'], 'Active')
     pprint(sso_url_parameters)
 except HPOneViewException as e:
     print("  %s" % e.msg['message'])
 
-# Remove the recently added enclosure
-oneview_client.enclosures.remove(enclosure)
-print("Enclosure removed successfully")
-
-# Get Statistics with defaults
-ENCLOSURE_ID = "09SGH102X6J1"
-
-print("Get enclosure statistics")
-try:
-    enclosure_statistics = oneview_client.enclosures.get_utilization(ENCLOSURE_ID)
-    pprint(enclosure_statistics)
-except HPOneViewException as e:
-    print(e.msg['message'])
-
 # Get Statistics specifying parameters
-print("Get enclosure statistics")
+print("Get the enclosure statistics")
 try:
-    enclosure_statistics = oneview_client.enclosures.get_utilization(ENCLOSURE_ID,
+    enclosure_statistics = oneview_client.enclosures.get_utilization(enclosure['uri'],
                                                                      fields='AveragePower',
-                                                                     filter='startDate=2016-05-30T03:29:42.000Z',
+                                                                     filter='startDate=2016-06-30T03:29:42.000Z',
                                                                      view='day')
     pprint(enclosure_statistics)
 except HPOneViewException as e:
     print(e.msg['message'])
+
+# Remove the recently added enclosure
+oneview_client.enclosures.remove(enclosure)
+print("Enclosure removed successfully")

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -243,12 +243,12 @@ class ResourceClient(object):
         filter = "\"'{0}'='{1}'\"".format(field, value)
         return self.get_all(filter=filter)
 
-    def get_utilization(self, id, fields=None, filter=None, refresh=False, view=None):
+    def get_utilization(self, id_or_uri, fields=None, filter=None, refresh=False, view=None):
         """
         Retrieves historical utilization data for the specified resource, metrics, and time span.
 
         Args:
-            id: resource identification
+            id_or_uri: resource identification
             fields:
                 Name of the supported metric(s) to be retrieved in the format METRIC[,METRIC]...
                 If unspecified, all metrics supported are returned.
@@ -308,7 +308,7 @@ class ResourceClient(object):
 
         """
 
-        if not id:
+        if not id_or_uri:
             raise ValueError(RESOURCE_CLIENT_INVALID_ID)
 
         query = ''
@@ -328,7 +328,7 @@ class ResourceClient(object):
         if query:
             query = "?" + query[1:]
 
-        uri = "{0}/{1}/utilization{2}".format(self._uri, id, query)
+        uri = "{0}/utilization{1}".format(self.build_uri(id_or_uri), query)
 
         return self._connection.get(uri)
 

--- a/hpOneView/resources/servers/enclosures.py
+++ b/hpOneView/resources/servers/enclosures.py
@@ -231,15 +231,15 @@ class Enclosures(object):
 
         Return: SSO (Single Sign-On) URL parameters
         """
-        uri = self._client.build_uri(id_or_uri) + "/sso?role='%s'" % role
+        uri = self._client.build_uri(id_or_uri) + "/sso?role=%s" % role
         return self._client.get(uri)
 
-    def get_utilization(self, id, fields=None, filter=None, refresh=False, view=None):
+    def get_utilization(self, id_or_uri, fields=None, filter=None, refresh=False, view=None):
         """
         Retrieves historical utilization data for the specified enclosure, metrics, and time span.
 
         Args:
-            id:
+            id: Could be either the resource id or the resource uri
             fields:
                  Name of the metric(s) to be retrieved in the format METRIC[,METRIC]... Enclosures support the following
                   utilization metrics:
@@ -313,4 +313,4 @@ class Enclosures(object):
 
         """
 
-        return self._client.get_utilization(id, fields=fields, filter=filter, refresh=refresh, view=view)
+        return self._client.get_utilization(id_or_uri, fields=fields, filter=filter, refresh=refresh, view=view)

--- a/tests/unit/resources/servers/test_enclosures.py
+++ b/tests/unit/resources/servers/test_enclosures.py
@@ -202,7 +202,7 @@ class EnclosuresTest(TestCase):
     @mock.patch.object(ResourceClient, 'get')
     def test_get_sso_by_uri(self, mock_get):
         uri_enclosure = '/rest/enclosures/ad28cf21-8b15-4f92-bdcf-51cb2042db32'
-        uri_rest_call = '/rest/enclosures/ad28cf21-8b15-4f92-bdcf-51cb2042db32/sso?role=\'Active\''
+        uri_rest_call = '/rest/enclosures/ad28cf21-8b15-4f92-bdcf-51cb2042db32/sso?role=Active'
 
         self._enclosures.get_sso(uri_enclosure, 'Active')
 
@@ -211,7 +211,7 @@ class EnclosuresTest(TestCase):
     @mock.patch.object(ResourceClient, 'get')
     def test_get_sso_by_id(self, mock_get):
         id_enclosure = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
-        uri_rest_call = '/rest/enclosures/ad28cf21-8b15-4f92-bdcf-51cb2042db32/sso?role=\'Active\''
+        uri_rest_call = '/rest/enclosures/ad28cf21-8b15-4f92-bdcf-51cb2042db32/sso?role=Active'
 
         self._enclosures.get_sso(id_enclosure, 'Active')
 
@@ -228,7 +228,14 @@ class EnclosuresTest(TestCase):
                                                      refresh=True, view='day')
 
     @mock.patch.object(ResourceClient, 'get_utilization')
-    def test_get_utilization_with_defaults(self, mock_get):
+    def test_get_utilization_by_id_with_defaults(self, mock_get):
         self._enclosures.get_utilization('09USE7335NW3')
 
         mock_get.assert_called_once_with('09USE7335NW3', fields=None, filter=None, refresh=False, view=None)
+
+    @mock.patch.object(ResourceClient, 'get_utilization')
+    def test_get_utilization_by_uri_with_defaults(self, mock_get):
+        self._enclosures.get_utilization('/rest/enclosures/09USE7335NW3')
+
+        mock_get.assert_called_once_with('/rest/enclosures/09USE7335NW3',
+                                         fields=None, filter=None, refresh=False, view=None)

--- a/tests/unit/resources/test_resource.py
+++ b/tests/unit/resources/test_resource.py
@@ -437,8 +437,16 @@ class ResourceTest(unittest.TestCase):
         mock_get.assert_called_once_with(expected_uri)
 
     @mock.patch.object(connection, 'get')
-    def test_get_utilization_with_defaults(self, mock_get):
+    def test_get_utilization_by_id_with_defaults(self, mock_get):
         self.resource_client.get_utilization('09USE7335NW3')
+
+        expected_uri = '/rest/testuri/09USE7335NW3/utilization'
+
+        mock_get.assert_called_once_with(expected_uri)
+
+    @mock.patch.object(connection, 'get')
+    def test_get_utilization_by_uri_with_defaults(self, mock_get):
+        self.resource_client.get_utilization('/rest/testuri/09USE7335NW3')
 
         expected_uri = '/rest/testuri/09USE7335NW3/utilization'
 


### PR DESCRIPTION
I've made some minor changes:
- Removed the example of the method that updates the calibrated the max power, since this property is read-only for the enclosure that is being created.
- Removed the example that gets the statistics of an enclosure with no filters, because it was retrieving a huge JSON;
- Changed the printed messages in the example, to make it clearer;
- Allows the user get the enclosure utilization providing either an ID or an URI.
- Fixed the method that build the Single Sign-On URL parameters for the enclosure, that previously was throwing an exception.