### PR TITLE
Changes connection to support custom headers in the http request

### DIFF
--- a/hpOneView/connection.py
+++ b/hpOneView/connection.py
@@ -63,6 +63,7 @@ logger = logging.getLogger(__name__)
 
 
 class connection(object):
+
     def __init__(self, applianceIp):
         self._session = None
         self._host = applianceIp
@@ -117,12 +118,16 @@ class connection(object):
     def make_url(self, path):
         return 'https://%s%s' % (self._host, path)
 
-    def do_http(self, method, path, body):
+    def do_http(self, method, path, body, custom_headers=None):
+        http_headers = self._headers.copy()
+        if custom_headers:
+            http_headers.update(custom_headers)
+
         bConnected = False
         while bConnected is False:
             try:
                 conn = self.get_connection()
-                conn.request(method, path, body, self._headers)
+                conn.request(method, path, body, http_headers)
                 resp = conn.getresponse()
                 try:
                     tempbytes = resp.read()
@@ -200,15 +205,6 @@ class connection(object):
         fin.close()
         return content_type
 
-    def patch(self, uri, body):
-        resp, body = self.do_http('PATCH', uri, json.dumps(body))
-        if resp.status >= 400:
-            raise HPOneViewException(body)
-        elif resp.status == 202:
-            task = self.get(resp.getheader('Location'))
-            return task, body
-        return None, body
-
     def post_multipart(self, uri, fields, files, baseName, verbose=False):
         content_type = self.encode_multipart_formdata(fields, files, baseName,
                                                       verbose)
@@ -285,23 +281,17 @@ class connection(object):
             members = self.getPrevPage()
         return members
 
-    def put(self, uri, body):
-        resp, body = self.do_http('PUT', uri, json.dumps(body))
-        if resp.status >= 400:
-            raise HPOneViewException(body)
-        elif resp.status == 202:
-            task = self.get(resp.getheader('Location'))
-            return task, body
-        return None, body
+    def delete(self, uri, custom_headers=None):
+        return self.__do_rest_call('DELETE', uri, '', custom_headers=custom_headers)
 
-    def post(self, uri, body):
-        resp, body = self.do_http('POST', uri, json.dumps(body))
-        if resp.status >= 400:
-            raise HPOneViewException('response: %s\n%s' % (resp.status, body))
-        elif resp.status == 202:
-            task = self.get(resp.getheader('Location'))
-            return task, body
-        return None, body
+    def put(self, uri, body, custom_headers=None):
+        return self.__do_rest_call('PUT', uri, body, custom_headers=custom_headers)
+
+    def post(self, uri, body, custom_headers=None):
+        return self.__do_rest_call('POST', uri, body, custom_headers=custom_headers)
+
+    def patch(self, uri, body, custom_headers=None):
+        return self.__do_rest_call('PATCH', uri, body, custom_headers=custom_headers)
 
     def get_entities_byrange(self, uri, field, xmin, xmax, count=-1):
         new_uri = uri + '?filter="\'' + field + '\'%20>%20\'' + xmin \
@@ -352,9 +342,12 @@ class connection(object):
                 raise e
         return entity
 
-    def delete(self, uri):
-        resp, body = self.do_http('DELETE', uri, '')
-        if resp.status >= 400 and resp.status != 404:
+    def __do_rest_call(self, http_method, uri, body, custom_headers):
+        resp, body = self.do_http(method=http_method,
+                                  path=uri,
+                                  body=json.dumps(body),
+                                  custom_headers=custom_headers)
+        if resp.status >= 400:
             raise HPOneViewException(body)
         elif resp.status == 202:
             task = self.get(resp.getheader('Location'))

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -99,7 +99,7 @@ class ResourceClient(object):
 
         return result
 
-    def delete(self, resource, force=False, timeout=-1):
+    def delete(self, resource, force=False, timeout=-1, custom_headers=None):
 
         if not resource:
             logger.exception(RESOURCE_CLIENT_RESOURCE_WAS_NOT_PROVIDED)
@@ -120,7 +120,7 @@ class ResourceClient(object):
         logger.debug("Delete resource (uri = %s, resource = %s)" %
                      (self._uri, str(resource)))
 
-        task, body = self._connection.delete(uri)
+        task, body = self._connection.delete(uri, custom_headers=custom_headers)
 
         if not task:
             # 204 NO CONTENT
@@ -160,17 +160,17 @@ class ResourceClient(object):
         response = self._connection.get(uri)
         return self.__get_members(response)
 
-    def update_with_zero_body(self, uri, timeout=-1):
+    def update_with_zero_body(self, uri, timeout=-1, custom_headers=None):
         logger.debug('Update with zero length body (uri = %s)' % uri)
 
-        task, body = self._connection.put(uri, None)
+        task, body = self._connection.put(uri, None, custom_headers=custom_headers)
 
         if not task:
             return body
 
         return self._task_monitor.wait_for_task(task, timeout)
 
-    def update(self, resource, uri=None, force=False, timeout=-1):
+    def update(self, resource, uri=None, force=False, timeout=-1, custom_headers=None):
         if not resource:
             logger.exception(RESOURCE_CLIENT_RESOURCE_WAS_NOT_PROVIDED)
             raise ValueError(RESOURCE_CLIENT_RESOURCE_WAS_NOT_PROVIDED)
@@ -184,14 +184,14 @@ class ResourceClient(object):
         if force:
             uri += '?force=True'
 
-        task, body = self._connection.put(uri, resource)
+        task, body = self._connection.put(uri, resource, custom_headers=custom_headers)
 
         if not task:
             return body
 
         return self._task_monitor.wait_for_task(task, timeout)
 
-    def create(self, resource, uri=None, timeout=-1):
+    def create(self, resource, uri=None, timeout=-1, custom_headers=None):
         if not resource:
             logger.exception(RESOURCE_CLIENT_RESOURCE_WAS_NOT_PROVIDED)
             raise ValueError(RESOURCE_CLIENT_RESOURCE_WAS_NOT_PROVIDED)
@@ -202,14 +202,14 @@ class ResourceClient(object):
         logger.debug('Create (uri = %s, resource = %s)' %
                      (uri, str(resource)))
 
-        task, entity = self._connection.post(uri, resource)
+        task, entity = self._connection.post(uri, resource, custom_headers=custom_headers)
 
         if not task:
             return entity
 
         return self._task_monitor.wait_for_task(task, timeout)
 
-    def patch(self, id_or_uri, operation, path, value, timeout=-1):
+    def patch(self, id_or_uri, operation, path, value, timeout=-1, custom_headers=None):
         """
         Uses the PATCH to update a resource.
         Only one operation can be performed in each PATCH call.
@@ -230,7 +230,7 @@ class ResourceClient(object):
             uri, operation, path, value))
 
         patch_request = [{'op': operation, 'path': path, 'value': value}]
-        task, entity = self._connection.patch(uri, patch_request)
+        task, entity = self._connection.patch(uri, patch_request, custom_headers=custom_headers)
 
         if not task:
             return entity

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -1,0 +1,389 @@
+# -*- coding: utf-8 -*-
+###
+# (C) Copyright (2016) Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+###
+import json
+import mock
+import unittest
+
+from http.client import HTTPSConnection
+from hpOneView.connection import connection
+from hpOneView.exceptions import HPOneViewException
+from mock import call
+
+
+class ConnectionTest(unittest.TestCase):
+
+    def setUp(self):
+        self.host = '127.0.0.1'
+        self.connection = connection(self.host)
+        self.accept_language_header = {
+            'Accept-Language': 'en_US'
+        }
+        self.default_headers = {
+            'X-API-Version': 200,
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        }
+        self.merged_headers = {
+            'X-API-Version': 200,
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Accept-Language': 'en_US'
+        }
+        self.request_body = {"request body": "content"}
+        self.response_body = {"response body": "content"}
+        self.dumped_request_body = json.dumps(self.request_body.copy())
+        self.expected_response_body = self.response_body.copy()
+
+    def __make_http_response(self, status):
+        mock_response = mock.Mock(status=status)
+        mock_response.read.return_value = json.dumps(self.response_body).encode('utf-8')
+        if status == 200 or status == 202:
+            mock_response.getheader.return_value = '/task/uri'
+        return mock_response
+
+    def test_default_headers(self):
+        self.assertEqual(self.default_headers, self.connection._headers)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_post_should_do_rest_call_when_status_ok(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=200)
+
+        self.connection.post('/path', self.request_body)
+
+        mock_request.assert_called_once_with('POST', '/path', self.dumped_request_body, self.default_headers)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_post_should_do_rest_calls_when_status_accepted(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=202)
+
+        self.connection.post('/path', self.request_body)
+
+        expected_calls = [call('POST', '/path', self.dumped_request_body, self.default_headers),
+                          call('GET', '/task/uri', '', self.default_headers)]
+        self.assertEquals(expected_calls, mock_request.call_args_list)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_post_should_send_merged_headers_when_headers_provided(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=202)
+
+        self.connection.post('/path', self.request_body, custom_headers=self.accept_language_header)
+
+        expected_calls = [call('POST', mock.ANY, mock.ANY, self.merged_headers), mock.ANY]
+        self.assertEquals(expected_calls, mock_request.call_args_list)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_post_should_return_body_when_status_ok(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=200)
+
+        result = self.connection.post('/path', self.response_body, custom_headers=self.accept_language_header)
+
+        expected_result = (None, self.expected_response_body)
+        self.assertEqual(expected_result, result)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_post_should_return_tuple_when_status_accepted(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=202)
+
+        result = self.connection.post('/path', self.response_body, custom_headers=self.accept_language_header)
+
+        expected_result = (self.expected_response_body, self.expected_response_body)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_post_should_raise_exception_when_status_internal_error(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=400)
+
+        try:
+            self.connection.post('/path', self.request_body)
+        except HPOneViewException as e:
+            self.assertEqual(e.msg, self.expected_response_body)
+        else:
+            self.fail()
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_post_should_raise_exception_when_status_not_found(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=404)
+
+        try:
+            self.connection.post('/path', self.request_body)
+        except HPOneViewException as e:
+            self.assertEqual(e.msg, self.expected_response_body)
+        else:
+            self.fail()
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_put_should_do_rest_call_when_status_ok(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=200)
+
+        self.connection.put('/path', self.request_body)
+
+        mock_request.assert_called_once_with('PUT', '/path', self.dumped_request_body, self.default_headers)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_put_should_do_rest_calls_when_status_accepted(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=202)
+
+        self.connection.put('/path', self.request_body)
+
+        expected_calls = [call('PUT', '/path', self.dumped_request_body, self.default_headers),
+                          call('GET', '/task/uri', '', self.default_headers)]
+        self.assertEquals(expected_calls, mock_request.call_args_list)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_put_should_send_merged_headers_when_headers_provided(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=202)
+
+        self.connection.put('/path', self.request_body, custom_headers=self.accept_language_header)
+
+        expected_calls = [call('PUT', mock.ANY, mock.ANY, self.merged_headers), mock.ANY]
+        self.assertEquals(expected_calls, mock_request.call_args_list)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_put_should_return_body_when_status_ok(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=200)
+
+        result = self.connection.put('/path', self.response_body, custom_headers=self.accept_language_header)
+
+        expected_result = (None, self.expected_response_body)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_put_should_return_tuple_when_status_accepted(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=202)
+
+        result = self.connection.put('/path', self.response_body, custom_headers=self.accept_language_header)
+
+        expected_result = (self.expected_response_body, self.expected_response_body)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_put_should_raise_exception_when_status_internal_error(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=400)
+
+        try:
+            self.connection.put('/path', self.request_body)
+        except HPOneViewException as e:
+            self.assertEqual(e.msg, self.expected_response_body)
+        else:
+            self.fail()
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_put_should_raise_exception_when_status_not_found(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=404)
+
+        try:
+            self.connection.put('/path', self.request_body)
+        except HPOneViewException as e:
+            self.assertEqual(e.msg, self.expected_response_body)
+        else:
+            self.fail()
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_patch_should_do_rest_call_when_status_ok(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=200)
+
+        self.connection.patch('/path', self.request_body)
+
+        mock_request.assert_called_once_with('PATCH', '/path', self.dumped_request_body, self.default_headers)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_patch_should_do_rest_calls_when_status_accepted(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=202)
+
+        self.connection.patch('/path', self.request_body)
+
+        expected_calls = [call('PATCH', '/path', self.dumped_request_body, self.default_headers),
+                          call('GET', '/task/uri', '', self.default_headers)]
+        self.assertEquals(expected_calls, mock_request.call_args_list)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_patch_should_send_merged_headers_when_headers_provided(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=202)
+
+        self.connection.patch('/path', self.request_body, custom_headers=self.accept_language_header)
+
+        expected_calls = [call('PATCH', mock.ANY, mock.ANY, self.merged_headers), mock.ANY]
+        self.assertEquals(expected_calls, mock_request.call_args_list)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_patch_should_return_body_when_status_ok(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=200)
+
+        result = self.connection.patch('/path', self.response_body, custom_headers=self.accept_language_header)
+
+        expected_result = (None, self.expected_response_body)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_patch_should_return_tuple_when_status_accepted(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=202)
+
+        result = self.connection.patch('/path', self.response_body, custom_headers=self.accept_language_header)
+
+        expected_result = (self.expected_response_body, self.expected_response_body)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_patch_should_raise_exception_when_status_internal_error(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=400)
+
+        try:
+            self.connection.patch('/path', self.request_body)
+        except HPOneViewException as e:
+            self.assertEqual(e.msg, self.expected_response_body)
+        else:
+            self.fail()
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_patch_should_raise_exception_when_status_not_found(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=404)
+
+        try:
+            self.connection.patch('/path', self.request_body)
+        except HPOneViewException as e:
+            self.assertEqual(e.msg, self.expected_response_body)
+        else:
+            self.fail()
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_delete_should_do_rest_calls_when_status_ok(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=200)
+
+        self.connection.delete('/path')
+
+        mock_request.assert_called_once_with('DELETE', '/path', json.dumps(''), self.default_headers)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_delete_should_do_rest_calls_when_status_accepted(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=202)
+
+        self.connection.delete('/path')
+
+        expected_calls = [call('DELETE', '/path', json.dumps(''), self.default_headers),
+                          call('GET', '/task/uri', '', self.default_headers)]
+        self.assertEquals(expected_calls, mock_request.call_args_list)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_delete_should_send_merged_headers_when_headers_provided(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=202)
+
+        self.connection.delete('/path', custom_headers=self.accept_language_header)
+
+        expected_calls = [call('DELETE', mock.ANY, mock.ANY, self.merged_headers), mock.ANY]
+        self.assertEquals(expected_calls, mock_request.call_args_list)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_delete_should_return_body_when_status_ok(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=200)
+
+        result = self.connection.delete('/path', custom_headers=self.accept_language_header)
+
+        expected_result = (None, self.expected_response_body)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_delete_should_return_tuple_when_status_accepted(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=202)
+
+        result = self.connection.delete('/path', custom_headers=self.accept_language_header)
+
+        expected_result = (self.expected_response_body, self.expected_response_body)
+        self.assertEqual(result, expected_result)
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_delete_should_raise_exception_when_status_internal_error(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=400)
+
+        try:
+            self.connection.delete('/path')
+        except HPOneViewException as e:
+            self.assertEqual(e.msg, self.expected_response_body)
+        else:
+            self.fail()
+
+    @mock.patch.object(HTTPSConnection, 'request')
+    @mock.patch.object(HTTPSConnection, 'getresponse')
+    def test_delete_should_raise_exception_when_status_not_found(self, mock_response, mock_request):
+        mock_request.return_value = {}
+        mock_response.return_value = self.__make_http_response(status=404)
+
+        try:
+            self.connection.delete('/path', self.request_body)
+        except HPOneViewException as e:
+            self.assertEqual(e.msg, self.expected_response_body)
+        else:
+            self.fail()


### PR DESCRIPTION
To create a Storage Volume Template, we need include the header 'Accept-Language' in the rest call, otherwise it returns an error.

We've changed the ResourceClient and connection classes to allow custom headers for post, put, patch and delete requests.

This PR also includes some refactoring.