### PR TITLE
Makes network resources compliant with recent changes

### DIFF
--- a/hpOneView/resources/networking/fc_networks.py
+++ b/hpOneView/resources/networking/fc_networks.py
@@ -89,8 +89,8 @@ class FcNetworks(object):
                  If set to true the operation completes despite any problems with
                  network connectivity or errors on the resource itself. The default is false.
             timeout:
-                Timeout in seconds. Wait task completion by default. The timeout do not abort the operation
-                in OneView, just stop waiting its completion.
+                Timeout in seconds. Wait task completion by default. The timeout does not abort the operation in
+                OneView, just stops waiting for its completion.
 
         Returns:
             bool:
@@ -115,15 +115,15 @@ class FcNetworks(object):
         Args:
             resource: dict object to create
             timeout:
-                Timeout in seconds. Wait task completion by default. The timeout do not abort the operation
-                in OneView, just stop waiting its completion.
+                Timeout in seconds. Wait task completion by default. The timeout does not abort the operation in
+                OneView, just stops waiting for its completion.
 
         Returns: Created resource.
 
         """
         data = self.__default_values.copy()
         data.update(resource)
-        return self._client.create(data, timeout)
+        return self._client.create(data, timeout=timeout)
 
     def update(self, resource, timeout=-1):
         """
@@ -132,8 +132,8 @@ class FcNetworks(object):
         Args:
             resource: dict object to update
             timeout:
-                Timeout in seconds. Wait task completion by default. The timeout do not abort the operation
-                in OneView, just stop waiting its completion.
+                Timeout in seconds. Wait task completion by default. The timeout does not abort the operation in
+                OneView, just stops waiting for its completion.
 
         Returns: Updated resource.
 

--- a/hpOneView/resources/networking/network_sets.py
+++ b/hpOneView/resources/networking/network_sets.py
@@ -76,7 +76,7 @@ class NetworkSets(object):
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
-    def delete(self, resource, force=False, blocking=True):
+    def delete(self, resource, force=False, timeout=-1):
         """
         Deletes a network set.
         Any deployed connections that are using the network are placed in the 'Failed' state.
@@ -86,13 +86,13 @@ class NetworkSets(object):
             force:
                  If set to true the operation completes despite any problems with
                  network connectivity or errors on the resource itself. The default is false.
-            blocking:
-                Wait task completion
+            timeout:
+                Timeout in seconds. Wait task completion by default. The timeout does not abort the operation in
+                OneView, just stops waiting for its completion.
 
         Returns: task
-
         """
-        return self._client.delete(resource, force=force, blocking=blocking)
+        return self._client.delete(resource, force=force, timeout=timeout)
 
     def get(self, id):
         """
@@ -104,37 +104,39 @@ class NetworkSets(object):
         """
         return self._client.get(id)
 
-    def create(self, resource, blocking=True):
+    def create(self, resource, timeout=-1):
         """
         Creates a network set.
 
         Args:
             resource: dict object to create
-            blocking:
-                Wait task completion. Default is True.
+            timeout:
+                Timeout in seconds. Wait task completion by default. The timeout does not abort the operation in
+                OneView, just stops waiting for its completion.
 
-        Returns: Created resource. When blocking=False, returns the task.
+        Returns: Created resource.
 
         """
         data = self.__default_values.copy()
         data.update(resource)
-        return self._client.create(data, blocking)
+        return self._client.create(data, timeout=timeout)
 
-    def update(self, resource, blocking=True):
+    def update(self, resource, timeout=-1):
         """
         Updates a network set.
 
         Args:
             resource: dict object to update
-            blocking:
-                Wait task completion. Default is True.
+            timeout:
+                Timeout in seconds. Wait task completion by default. The timeout does not abort the operation in
+                OneView, just stops waiting for its completion.
 
-        Returns: Updated resource. When blocking=False, returns the task.
+        Returns: Updated resource.
 
         """
         data = self.__default_values.copy()
         data.update(resource)
-        return self._client.update(data, blocking=blocking)
+        return self._client.update(data, timeout=timeout)
 
     def get_by(self, field, value):
         """

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -219,8 +219,8 @@ class ResourceClient(object):
             operation: Patch operation
             path: Path
             value: Value
-            timeout: Timeout in seconds. Wait task completion by default. The timeout do not abort the operation
-            in OneView, just stop waiting its completion.
+            timeout: Timeout in seconds. Wait task completion by default. The timeout does not abort the operation in
+                OneView, just stops waiting for its completion
 
         Returns: Updated resource.
         """

--- a/tests/unit/resources/networking/test_ethernet_networks.py
+++ b/tests/unit/resources/networking/test_ethernet_networks.py
@@ -60,8 +60,8 @@ class EthernetNetworksTest(TestCase):
         resource_rest_call = resource.copy()
         mock_create.return_value = {}
 
-        self._ethernet_networks.create(resource, False)
-        mock_create.assert_called_once_with(resource_rest_call, timeout=False)
+        self._ethernet_networks.create(resource, 12)
+        mock_create.assert_called_once_with(resource_rest_call, timeout=12)
 
     @mock.patch.object(ResourceClient, 'create')
     def test_create_should_use_default_values(self, mock_create):
@@ -99,10 +99,10 @@ class EthernetNetworksTest(TestCase):
         mock_create.return_value = {}
         mock_get_all.return_value = []
 
-        self._ethernet_networks.create_bulk(resource, False)
+        self._ethernet_networks.create_bulk(resource, 27)
 
         mock_create.assert_called_once_with(
-            resource_rest_call, uri='/rest/ethernet-networks/bulk', timeout=False)
+            resource_rest_call, uri='/rest/ethernet-networks/bulk', timeout=27)
         mock_get_all.assert_called_once_with(
             0, -1, filter='"\'name\' matches \'TestNetwork\\_%\'"', sort='vlanId:ascending')
 

--- a/tests/unit/resources/networking/test_fc_networks.py
+++ b/tests/unit/resources/networking/test_fc_networks.py
@@ -58,7 +58,7 @@ class FcNetworksTest(unittest.TestCase):
         mock_create.return_value = {}
 
         self._fc_networks.create(resource, 30)
-        mock_create.assert_called_once_with(resource_rest_call, 30)
+        mock_create.assert_called_once_with(resource_rest_call, timeout=30)
 
     @mock.patch.object(ResourceClient, 'create')
     def test_create_should_use_default_values(self, mock_create):
@@ -76,7 +76,7 @@ class FcNetworksTest(unittest.TestCase):
 
         self._fc_networks.create(resource)
 
-        mock_create.assert_called_once_with(resource_with_default_values, -1)
+        mock_create.assert_called_once_with(resource_with_default_values, timeout=-1)
 
     @mock.patch.object(ResourceClient, 'update')
     def test_update_should_use_given_values(self, mock_update):

--- a/tests/unit/resources/networking/test_network_sets.py
+++ b/tests/unit/resources/networking/test_network_sets.py
@@ -57,8 +57,8 @@ class NetworkSetsTest(unittest.TestCase):
         resource_rest_call = resource.copy()
         mock_create.return_value = {}
 
-        self._network_sets.create(resource, False)
-        mock_create.assert_called_once_with(resource_rest_call, False)
+        self._network_sets.create(resource, 10)
+        mock_create.assert_called_once_with(resource_rest_call, timeout=10)
 
     @mock.patch.object(ResourceClient, 'create')
     def test_create_should_use_default_values(self, mock_create):
@@ -74,7 +74,7 @@ class NetworkSetsTest(unittest.TestCase):
 
         self._network_sets.create(resource)
 
-        mock_create.assert_called_once_with(resource_with_default_values, True)
+        mock_create.assert_called_once_with(resource_with_default_values, timeout=-1)
 
     @mock.patch.object(ResourceClient, 'update')
     def test_update_should_use_given_values(self, mock_update):
@@ -87,8 +87,8 @@ class NetworkSetsTest(unittest.TestCase):
         resource_rest_call = resource.copy()
         mock_update.return_value = {}
 
-        self._network_sets.update(resource, False)
-        mock_update.assert_called_once_with(resource_rest_call, blocking=False)
+        self._network_sets.update(resource, 20)
+        mock_update.assert_called_once_with(resource_rest_call, timeout=20)
 
     @mock.patch.object(ResourceClient, 'update')
     def test_update_should_use_default_values(self, mock_update):
@@ -105,14 +105,14 @@ class NetworkSetsTest(unittest.TestCase):
         self._network_sets.update(resource)
 
         mock_update.assert_called_once_with(
-            resource_with_default_values, blocking=True)
+            resource_with_default_values, timeout=-1)
 
     @mock.patch.object(ResourceClient, 'delete')
     def test_delete_called_once(self, mock_delete):
         id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
-        self._network_sets.delete(id, force=False, blocking=True)
+        self._network_sets.delete(id, force=False)
 
-        mock_delete.assert_called_once_with(id, force=False, blocking=True)
+        mock_delete.assert_called_once_with(id, force=False, timeout=-1)
 
     @mock.patch.object(ResourceClient, 'get_by')
     def test_get_by_called_once(self, mock_get_by):


### PR DESCRIPTION
There were some recent changes made in the ResourceClient class. It caused issues in the Fc-Networks, Networks Sets and Ethernet Networks resources, since there was a bunch of code non-compliant with those changes.