### PR TITLE
Makes API Version configurable

### DIFF
--- a/examples/config-rename.json
+++ b/examples/config-rename.json
@@ -1,5 +1,6 @@
 {
   "ip": "172.16.102.59",
+  "api_version": 200,
   "credentials": {
     "userName": "administrator",
     "authLoginDomain": "",

--- a/hpOneView/connection.py
+++ b/hpOneView/connection.py
@@ -64,11 +64,11 @@ logger = logging.getLogger(__name__)
 
 class connection(object):
 
-    def __init__(self, applianceIp):
+    def __init__(self, applianceIp, api_version=200):
         self._session = None
         self._host = applianceIp
         self._cred = None
-        self._apiVersion = 200
+        self._apiVersion = api_version
         self._headers = {
             'X-API-Version': self._apiVersion,
             'Accept': 'application/json',

--- a/hpOneView/oneview_client.py
+++ b/hpOneView/oneview_client.py
@@ -81,8 +81,7 @@ ONEVIEW_CLIENT_INVALID_PROXY = 'Invalid Proxy format'
 
 class OneViewClient(object):
     def __init__(self, config):
-        self.__config = config
-        self.__connection = connection(config["ip"])
+        self.__connection = connection(config["ip"], config.get('api_version', 200))
         self.__set_proxy(config)
         self.__connection.login(config["credentials"])
         self.__connections = None

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -64,6 +64,13 @@ class ConnectionTest(unittest.TestCase):
     def test_default_headers(self):
         self.assertEqual(self.default_headers, self.connection._headers)
 
+    def test_headers_with_api_version_300(self):
+        self.connection = connection(self.host, 300)
+
+        expected_headers = self.default_headers.copy()
+        expected_headers['X-API-Version'] = 300
+        self.assertEqual(expected_headers, self.connection._headers)
+
     @mock.patch.object(HTTPSConnection, 'request')
     @mock.patch.object(HTTPSConnection, 'getresponse')
     def test_post_should_do_rest_call_when_status_ok(self, mock_response, mock_request):


### PR DESCRIPTION
The user will be able to configure the OneView API Version. The default value is 200.
This value is currently hardcoded.