### PR TITLE
Support to add and remove ethernet networks for an uplink set

### DIFF
--- a/examples/uplink_sets.py
+++ b/examples/uplink_sets.py
@@ -81,6 +81,11 @@ print("\nGet an uplink set by uri")
 uplink_set = oneview_client.uplink_sets.get(created_uplink_set['uri'])
 pprint(uplink_set)
 
+# Get the associated ethernet networks of an uplink set
+print("\nGet the associated ethernet networks of the uplink set")
+networks = oneview_client.uplink_sets.get_ethernet_networks(created_uplink_set['uri'])
+pprint(networks)
+
 # Delete the recently created uplink set
 print("\nDelete the uplink set")
 oneview_client.fc_networks.delete(updated_uplink_set)

--- a/examples/uplink_sets.py
+++ b/examples/uplink_sets.py
@@ -44,8 +44,11 @@ oneview_client = OneViewClient(config)
 options = {
     "name": "Uplink Set Demo",
     "status": "OK",
-    "logicalInterconnectUri": "",
-    "networkUris": [],
+    "logicalInterconnectUri": "/rest/logical-interconnects/0de81de6-6652-4861-94f9-9c24b2fd0d66",
+    "networkUris": [
+        '/rest/ethernet-networks/9e8472ad-5ad1-4cbd-aab1-566b67ffc6a4',
+        '/rest/ethernet-networks/28ea7c1a-4930-4432-854b-30cf239226a2'
+    ],
     "fcNetworkUris": [],
     "fcoeNetworkUris": [],
     "portConfigInfos": [],
@@ -75,6 +78,15 @@ for uplink_set in uplink_sets:
 print("\nGet uplink set by name")
 uplink_set = oneview_client.uplink_sets.get_by('name', 'Renamed Uplink Set Demo')[0]
 print("Found uplink set at uri '{uri}'\n  by name = '{name}'".format(**uplink_set))
+
+
+# Add an ethernet network to the uplink set
+# To run this example you must define an ethernet network uri or ID below
+ethernet_network_id = None
+if ethernet_network_id:
+    print("\nAdd an ethernet network to the uplink set")
+    uplink_set = oneview_client.uplink_sets.add_ethernet_networks(created_uplink_set['uri'], ethernet_network_id)
+    print("The uplink set with name = '{name}' have now the networkUris:\n {networkUris}".format(**uplink_set))
 
 # Get an uplink set resource by uri
 print("\nGet an uplink set by uri")

--- a/examples/uplink_sets.py
+++ b/examples/uplink_sets.py
@@ -40,14 +40,13 @@ config = try_load_from_file(config)
 
 oneview_client = OneViewClient(config)
 
-# To run this example you must define an interconnect uri (logicalInterconnectUri) bellow
+# To run this example you must define an interconnect uri (logicalInterconnectUri) and at leat one ethernet network
+# in 'networkUris' bellow
 options = {
     "name": "Uplink Set Demo",
     "status": "OK",
-    "logicalInterconnectUri": "/rest/logical-interconnects/0de81de6-6652-4861-94f9-9c24b2fd0d66",
+    "logicalInterconnectUri": "",
     "networkUris": [
-        '/rest/ethernet-networks/9e8472ad-5ad1-4cbd-aab1-566b67ffc6a4',
-        '/rest/ethernet-networks/28ea7c1a-4930-4432-854b-30cf239226a2'
     ],
     "fcNetworkUris": [],
     "fcoeNetworkUris": [],
@@ -79,7 +78,6 @@ print("\nGet uplink set by name")
 uplink_set = oneview_client.uplink_sets.get_by('name', 'Renamed Uplink Set Demo')[0]
 print("Found uplink set at uri '{uri}'\n  by name = '{name}'".format(**uplink_set))
 
-
 # Add an ethernet network to the uplink set
 # To run this example you must define an ethernet network uri or ID below
 ethernet_network_id = None
@@ -92,6 +90,14 @@ if ethernet_network_id:
 print("\nGet an uplink set by uri")
 uplink_set = oneview_client.uplink_sets.get(created_uplink_set['uri'])
 pprint(uplink_set)
+
+# Remove an ethernet network to the uplink set
+# To run this example you must define an ethernet network uri or ID below
+ethernet_network_id = None
+if ethernet_network_id:
+    print("\nRemove an ethernet network of the uplink set")
+    uplink_set = oneview_client.uplink_sets.remove_ethernet_networks(created_uplink_set['uri'], ethernet_network_id)
+    print("The uplink set with name = '{name}' have now the networkUris:\n {networkUris}".format(**uplink_set))
 
 # Get the associated ethernet networks of an uplink set
 print("\nGet the associated ethernet networks of the uplink set")

--- a/hpOneView/resources/networking/ethernet_networks.py
+++ b/hpOneView/resources/networking/ethernet_networks.py
@@ -97,15 +97,16 @@ class EthernetNetworks(object):
         """
         return self._client.delete(resource, force=force, timeout=timeout)
 
-    def get(self, id):
+    def get(self, id_or_uri):
         """
-        Gets the Ethernet network with the specified ID
+        Gets the Ethernet network
         Args:
-            id: ID of Ethernet network
+            id_or_uri: ID or uri of Ethernet network
 
-        Returns: dict
+        Returns:
+            dict: The ethernet network
         """
-        return self._client.get(id)
+        return self._client.get(id_or_uri)
 
     def create(self, resource, timeout=-1):
         """

--- a/hpOneView/resources/networking/uplink_sets.py
+++ b/hpOneView/resources/networking/uplink_sets.py
@@ -38,6 +38,7 @@ __license__ = 'MIT'
 __status__ = 'Development'
 
 from hpOneView.resources.resource import ResourceClient
+from hpOneView.resources.networking.ethernet_networks import EthernetNetworks
 
 
 class UplinkSets(object):
@@ -46,7 +47,7 @@ class UplinkSets(object):
     def __init__(self, con):
         self._connection = con
         self._client = ResourceClient(con, self.URI)
-
+        self._ethernet_network = EthernetNetworks(con)
         self.__default_values = {
             "type": "uplink-setV3",
         }
@@ -161,3 +162,21 @@ class UplinkSets(object):
 
         """
         return self._client.delete(resource, force=force, timeout=timeout)
+
+    def get_ethernet_networks(self, id_or_uri):
+        """
+        Gets a list of associated ethernet networks of an uplink set
+        Args:
+            id_or_uri:
+                Could be either the uplink set id or the uplink set uri
+
+        Returns:
+            list: Associated ethernet networks
+        """
+        uplink = self.get(id_or_uri)
+        network_uris = uplink.get('networkUris')
+        networks = []
+        if network_uris:
+            for uri in network_uris:
+                networks.append(self._ethernet_network.get(uri))
+        return networks

--- a/hpOneView/resources/networking/uplink_sets.py
+++ b/hpOneView/resources/networking/uplink_sets.py
@@ -39,6 +39,7 @@ __status__ = 'Development'
 
 from hpOneView.resources.resource import ResourceClient
 from hpOneView.resources.networking.ethernet_networks import EthernetNetworks
+from builtins import isinstance
 
 
 class UplinkSets(object):
@@ -180,3 +181,33 @@ class UplinkSets(object):
             for uri in network_uris:
                 networks.append(self._ethernet_network.get(uri))
         return networks
+
+    def add_ethernet_networks(self, id_or_uri, ethernet_id_or_uris):
+        """
+        Adds existing ethernet networks to an uplink set
+        Args:
+            id_or_uri:
+                Could be either the uplink set id or the uplink set uri
+            ethernet_id_or_uris:
+                Could be either one or more ethernet network id or ethernet network uri
+
+        Returns:
+            dict: The updated uplink set
+        """
+        if not isinstance(ethernet_id_or_uris, list):
+            ethernet_id_or_uris = [ethernet_id_or_uris]
+
+        uplink = self.get(id_or_uri)
+
+        associated_enets = uplink.get('networkUris', [])
+
+        for i, enet in enumerate(ethernet_id_or_uris):
+            ethernet_id_or_uris[i] = enet if '/' in enet else self._ethernet_network.URI + '/' + enet
+
+        missing_enets = sorted(list(set(ethernet_id_or_uris) - set(associated_enets)))
+
+        if len(missing_enets) > 0:
+            uplink['networkUris'] = missing_enets + associated_enets
+            return self.update(uplink)
+        else:
+            return uplink

--- a/hpOneView/resources/networking/uplink_sets.py
+++ b/hpOneView/resources/networking/uplink_sets.py
@@ -194,6 +194,23 @@ class UplinkSets(object):
         Returns:
             dict: The updated uplink set
         """
+        return self.__set_ethernet_uris(id_or_uri, ethernet_id_or_uris, operation="add")
+
+    def remove_ethernet_networks(self, id_or_uri, ethernet_id_or_uris):
+        """
+        Remove existing ethernet networks of an uplink set
+        Args:
+            id_or_uri:
+                Could be either the uplink set id or the uplink set uri
+            ethernet_id_or_uris:
+                Could be either one or more ethernet network id or ethernet network uri
+
+        Returns:
+            dict: The updated uplink set
+        """
+        return self.__set_ethernet_uris(id_or_uri, ethernet_id_or_uris, operation="remove")
+
+    def __set_ethernet_uris(self, id_or_uri, ethernet_id_or_uris, operation="add"):
         if not isinstance(ethernet_id_or_uris, list):
             ethernet_id_or_uris = [ethernet_id_or_uris]
 
@@ -204,10 +221,15 @@ class UplinkSets(object):
         for i, enet in enumerate(ethernet_id_or_uris):
             ethernet_id_or_uris[i] = enet if '/' in enet else self._ethernet_network.URI + '/' + enet
 
-        missing_enets = sorted(list(set(ethernet_id_or_uris) - set(associated_enets)))
+        if operation == "remove":
+            enets_to_update = sorted(list(set(associated_enets) - set(ethernet_id_or_uris)))
+        elif operation == "add":
+            enets_to_update = sorted(list(set(associated_enets).union(set(ethernet_id_or_uris))))
+        else:
+            raise ValueError("Value {} is not supported as operation. The supported values are: ['add', 'remove']")
 
-        if len(missing_enets) > 0:
-            uplink['networkUris'] = missing_enets + associated_enets
+        if set(enets_to_update) != set(associated_enets):
+            uplink['networkUris'] = enets_to_update
             return self.update(uplink)
         else:
             return uplink

--- a/tests/unit/resources/networking/test_uplink_sets.py
+++ b/tests/unit/resources/networking/test_uplink_sets.py
@@ -26,6 +26,7 @@ import unittest
 import mock
 
 from hpOneView.connection import connection
+from hpOneView.resources.networking.ethernet_networks import EthernetNetworks
 from hpOneView.resources.networking.uplink_sets import UplinkSets
 from hpOneView.resources.resource import ResourceClient
 
@@ -125,3 +126,39 @@ class UplinkSetsTest(unittest.TestCase):
         self._uplink_sets.delete(id, force=False, timeout=-1)
 
         mock_delete.assert_called_once_with(id, force=False, timeout=-1)
+
+    @mock.patch.object(EthernetNetworks, 'get')
+    @mock.patch.object(UplinkSets, 'get')
+    def test_get_ethernet_networks(self, mock_uplink_get, mock_get_enet):
+        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+        uplink = {
+            'name': 'UplinkName',
+            'networkUris': ['/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
+                            '/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188',
+                            '/rest/ethernet-networks/fg0dcf5e-1589-4mn0-852f-85hd6a067963',
+                            ],
+        }
+
+        result_get_enet = [
+            {'name': 'Ethernet Network 1'},
+            {'name': 'Ethernet Network 2'},
+            {'name': 'Ethernet Network 3'},
+        ]
+
+        mock_uplink_get.return_value = uplink
+        mock_get_enet.side_effect = result_get_enet
+        result = self._uplink_sets.get_ethernet_networks(id)
+        self.assertEqual(mock_get_enet.call_count, 3)
+        self.assertEqual(result_get_enet, result)
+
+    @mock.patch.object(EthernetNetworks, 'get')
+    @mock.patch.object(UplinkSets, 'get')
+    def test_get_ethernet_networks_with_empty_list(self, mock_uplink_get, mock_get_enet):
+        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+        uplink = {
+            'name': 'UplinkName',
+        }
+
+        mock_uplink_get.return_value = uplink
+        result = self._uplink_sets.get_ethernet_networks(id)
+        self.assertEqual([], result)

--- a/tests/unit/resources/networking/test_uplink_sets.py
+++ b/tests/unit/resources/networking/test_uplink_sets.py
@@ -291,3 +291,91 @@ class UplinkSetsTest(unittest.TestCase):
         result = self._uplink_sets.add_ethernet_networks(id, ethernet_to_add)
         self.assertEqual(mock_uplink_update.call_count, 0)
         self.assertEqual(uplink, result)
+
+    @mock.patch.object(UplinkSets, 'update')
+    @mock.patch.object(UplinkSets, 'get')
+    def test_remove_one_ethernet_network(self, mock_uplink_get, mock_uplink_update):
+        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+        ethernet_to_remove = '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939'
+        uplink = {
+            'name': 'UplinkName',
+            'networkUris': ['/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939', ]
+        }
+
+        uplink_to_update = {
+            'name': 'UplinkName',
+            'networkUris': []
+        }
+
+        mock_uplink_get.return_value = uplink
+        self._uplink_sets.remove_ethernet_networks(id, ethernet_to_remove)
+        mock_uplink_update.assert_called_once_with(uplink_to_update)
+
+    @mock.patch.object(UplinkSets, 'update')
+    @mock.patch.object(UplinkSets, 'get')
+    def test_remove_a_list_of_ethernet_networks(self, mock_uplink_get, mock_uplink_update):
+        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+        ethernet_to_remove = [
+            '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
+            '/rest/ethernet-networks/134dcf5e-0d8e-441c-b00d-e1dd6a067188',
+        ]
+        uplink = {
+            'name': 'UplinkName',
+            'networkUris': ['/rest/ethernet-networks/134dcf5e-0d8e-441c-b00d-e1dd6a067188',
+                            '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
+                            '/rest/ethernet-networks/45gdo84i-6jgf-093b-gsd5-njkn543tb64l', ]
+        }
+
+        uplink_to_update = {
+            'name': 'UplinkName',
+            'networkUris': ['/rest/ethernet-networks/45gdo84i-6jgf-093b-gsd5-njkn543tb64l', ]
+        }
+
+        mock_uplink_get.return_value = uplink
+        self._uplink_sets.remove_ethernet_networks(id, ethernet_to_remove)
+        mock_uplink_update.assert_called_once_with(uplink_to_update)
+
+    @mock.patch.object(UplinkSets, 'update')
+    @mock.patch.object(UplinkSets, 'get')
+    def test_remove_a_list_of_ethernet_network_ids(self, mock_uplink_get, mock_uplink_update):
+        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+        ethernet_to_remove = [
+            '5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
+            '134dcf5e-0d8e-441c-b00d-e1dd6a067188',
+        ]
+        uplink = {
+            'name': 'UplinkName',
+            'networkUris': ['/rest/ethernet-networks/134dcf5e-0d8e-441c-b00d-e1dd6a067188',
+                            '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
+                            '/rest/ethernet-networks/45gdo84i-6jgf-093b-gsd5-njkn543tb64l', ]
+        }
+
+        uplink_to_update = {
+            'name': 'UplinkName',
+            'networkUris': ['/rest/ethernet-networks/45gdo84i-6jgf-093b-gsd5-njkn543tb64l', ]
+        }
+        uplink_return = uplink_to_update.copy()
+
+        mock_uplink_update.return_value = uplink_return
+        mock_uplink_get.return_value = uplink
+
+        result = self._uplink_sets.remove_ethernet_networks(id, ethernet_to_remove)
+        mock_uplink_update.assert_called_once_with(uplink_to_update)
+        self.assertEqual(uplink_return, result)
+
+    @mock.patch.object(UplinkSets, 'update')
+    @mock.patch.object(UplinkSets, 'get')
+    def test_not_remove_ethernet_networks_already_not_associated(self, mock_uplink_get, mock_uplink_update):
+        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+        ethernet_to_remove = [
+            'd34dcf5e-0d8e-441c-b00d-e1dd6a067188',
+        ]
+        uplink = {
+            'name': 'UplinkName',
+            'networkUris': ['/rest/ethernet-networks/45gdo84i-6jgf-093b-gsd5-njkn543tb64l', ]
+        }
+
+        mock_uplink_get.return_value = uplink
+        result = self._uplink_sets.remove_ethernet_networks(id, ethernet_to_remove)
+        self.assertEqual(mock_uplink_update.call_count, 0)
+        self.assertEqual(uplink, result)

--- a/tests/unit/resources/networking/test_uplink_sets.py
+++ b/tests/unit/resources/networking/test_uplink_sets.py
@@ -151,9 +151,8 @@ class UplinkSetsTest(unittest.TestCase):
         self.assertEqual(mock_get_enet.call_count, 3)
         self.assertEqual(result_get_enet, result)
 
-    @mock.patch.object(EthernetNetworks, 'get')
     @mock.patch.object(UplinkSets, 'get')
-    def test_get_ethernet_networks_with_empty_list(self, mock_uplink_get, mock_get_enet):
+    def test_get_ethernet_networks_with_empty_list(self, mock_uplink_get):
         id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
         uplink = {
             'name': 'UplinkName',
@@ -162,3 +161,133 @@ class UplinkSetsTest(unittest.TestCase):
         mock_uplink_get.return_value = uplink
         result = self._uplink_sets.get_ethernet_networks(id)
         self.assertEqual([], result)
+
+    @mock.patch.object(UplinkSets, 'update')
+    @mock.patch.object(UplinkSets, 'get')
+    def test_add_one_ethernet_network(self, mock_uplink_get, mock_uplink_update):
+        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+        ethernet_to_add = '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939'
+        uplink = {
+            'name': 'UplinkName',
+        }
+
+        uplink_to_update = {
+            'name': 'UplinkName',
+            'networkUris': ['/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939', ]
+        }
+
+        mock_uplink_get.return_value = uplink
+        self._uplink_sets.add_ethernet_networks(id, ethernet_to_add)
+        mock_uplink_update.assert_called_once_with(uplink_to_update)
+
+    @mock.patch.object(UplinkSets, 'update')
+    @mock.patch.object(UplinkSets, 'get')
+    def test_add_a_list_of_ethernet_networks(self, mock_uplink_get, mock_uplink_update):
+        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+        ethernet_to_add = [
+            '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
+            '/rest/ethernet-networks/134dcf5e-0d8e-441c-b00d-e1dd6a067188',
+        ]
+        uplink = {
+            'name': 'UplinkName',
+        }
+
+        uplink_to_update = {
+            'name': 'UplinkName',
+            'networkUris': ['/rest/ethernet-networks/134dcf5e-0d8e-441c-b00d-e1dd6a067188',
+                            '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939', ]
+        }
+
+        mock_uplink_get.return_value = uplink
+        self._uplink_sets.add_ethernet_networks(id, ethernet_to_add)
+        mock_uplink_update.assert_called_once_with(uplink_to_update)
+
+    @mock.patch.object(UplinkSets, 'update')
+    @mock.patch.object(UplinkSets, 'get')
+    def test_add_a_list_of_ethernet_network_uris(self, mock_uplink_get, mock_uplink_update):
+        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+        ethernet_to_add = [
+            '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
+            '/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188',
+        ]
+        uplink = {
+            'name': 'UplinkName',
+        }
+
+        uplink_to_update = {
+            'name': 'UplinkName',
+            'networkUris': ['/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
+                            '/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188', ]
+        }
+
+        mock_uplink_get.return_value = uplink
+        self._uplink_sets.add_ethernet_networks(id, ethernet_to_add)
+        mock_uplink_update.assert_called_once_with(uplink_to_update)
+
+    @mock.patch.object(UplinkSets, 'update')
+    @mock.patch.object(UplinkSets, 'get')
+    def test_add_a_list_of_ethernet_network_ids(self, mock_uplink_get, mock_uplink_update):
+        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+        ethernet_to_add = [
+            '5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
+            'd34dcf5e-0d8e-441c-b00d-e1dd6a067188',
+        ]
+        uplink = {
+            'name': 'UplinkName',
+        }
+        uplink_to_update = {
+            'name': 'UplinkName',
+            'networkUris': ['/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
+                            '/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188', ]
+        }
+        uplink_return = uplink_to_update.copy()
+
+        mock_uplink_update.return_value = uplink_return
+        mock_uplink_get.return_value = uplink
+
+        result = self._uplink_sets.add_ethernet_networks(id, ethernet_to_add)
+        mock_uplink_update.assert_called_once_with(uplink_to_update)
+        self.assertEqual(uplink_return, result)
+
+    @mock.patch.object(UplinkSets, 'update')
+    @mock.patch.object(UplinkSets, 'get')
+    def test_add_missing_ethernet_networks(self, mock_uplink_get, mock_uplink_update):
+        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+        ethernet_to_add = [
+            '5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
+            'd34dcf5e-0d8e-441c-b00d-e1dd6a067188',
+        ]
+        uplink = {
+            'name': 'UplinkName',
+            'networkUris': ['/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188', ]
+        }
+        uplink_to_update = {
+            'name': 'UplinkName',
+            'networkUris': ['/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
+                            '/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188', ]
+        }
+        uplink_return = uplink_to_update.copy()
+
+        mock_uplink_get.return_value = uplink
+        mock_uplink_update.return_value = uplink_return
+
+        result = self._uplink_sets.add_ethernet_networks(id, ethernet_to_add)
+        mock_uplink_update.assert_called_once_with(uplink_to_update)
+        self.assertEqual(uplink_return, result)
+
+    @mock.patch.object(UplinkSets, 'update')
+    @mock.patch.object(UplinkSets, 'get')
+    def test_not_add_ethernet_networks_already_associated(self, mock_uplink_get, mock_uplink_update):
+        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+        ethernet_to_add = [
+            'd34dcf5e-0d8e-441c-b00d-e1dd6a067188',
+        ]
+        uplink = {
+            'name': 'UplinkName',
+            'networkUris': ['/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188', ]
+        }
+
+        mock_uplink_get.return_value = uplink
+        result = self._uplink_sets.add_ethernet_networks(id, ethernet_to_add)
+        self.assertEqual(mock_uplink_update.call_count, 0)
+        self.assertEqual(uplink, result)


### PR DESCRIPTION
Add support to:

- Add one or more ethernet networks to an uplink set
- Remove one or more ethernet networks of an uplink set
- Get The list of associated ethernet networks of an uplink set