### PR TITLE
Changes get_all to return all items matching the specified filter for all resouces

### DIFF
--- a/examples/logical_interconnects.py
+++ b/examples/logical_interconnects.py
@@ -135,10 +135,10 @@ pprint(snmp_configuration)
 try:
     print("Update the SNMP configuration for the logical interconnect")
     snmp_configuration['enabled'] = True
-    snmp_configuration = oneview_client.logical_interconnects.update_snmp_configuration(
-        logical_interconnect['uri'], snmp_configuration)
-    print("  Updated port monitor at uri: {uri}\n  with 'enabled': '{enabled}'".format(
-        **snmp_configuration))
+    logical_interconnect = oneview_client.logical_interconnects.update_snmp_configuration(logical_interconnect['uri'],
+                                                                                          snmp_configuration)
+    interconnect_snmp = logical_interconnect['snmpConfiguration']
+    print("  Updated port monitor at uri: {uri}\n  with 'enabled': '{enabled}'".format(**interconnect_snmp))
 except HPOneViewException as e:
     print(e.msg['message'])
 

--- a/hpOneView/resources/activity/tasks.py
+++ b/hpOneView/resources/activity/tasks.py
@@ -71,7 +71,7 @@ class Tasks(object):
             count:
                 The number of resources to return. A count of -1 requests all the items. The actual number of items in
                 the response may differ from the requested count if the sum of start and count exceed the total number
-                of items, or if returning the requested number of items would take too long.
+                of items.
             fields:
                  Specifies which fields should be returned in the result set.
             filter:
@@ -89,8 +89,7 @@ class Tasks(object):
                  collections of resources.
 
         Returns:
-            dict: tasks
-
+            list: A list of tasks.
         """
         return self._client.get_all(start=start, count=count, filter=filter, query=query, sort=sort, view=view,
                                     fields=fields)

--- a/hpOneView/resources/networking/connection_templates.py
+++ b/hpOneView/resources/networking/connection_templates.py
@@ -61,8 +61,7 @@ class ConnectionTemplates(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -70,8 +69,8 @@ class ConnectionTemplates(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
 
-        Returns: dict
-
+        Returns:
+            list: A list of connection templates.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -94,8 +93,8 @@ class ConnectionTemplates(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict
-
+        Returns:
+            list: A list of connection templates.
         """
         return self._client.get_by(field, value)
 

--- a/hpOneView/resources/networking/ethernet_networks.py
+++ b/hpOneView/resources/networking/ethernet_networks.py
@@ -63,8 +63,7 @@ class EthernetNetworks(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -72,8 +71,8 @@ class EthernetNetworks(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
 
-        Returns: dict
-
+        Returns:
+            list: A list of ethernet networks.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -167,7 +166,7 @@ class EthernetNetworks(object):
             vlan_id_range: A combination of values or ranges to be retrieved. For example '1-10,50,51,500-700'.
 
         Returns:
-            list: List of Ethernet Networks.
+            list: A list of Ethernet Networks.
 
         """
         filter = '"\'name\' matches \'{}\_%\'"'.format(name_prefix)
@@ -236,8 +235,8 @@ class EthernetNetworks(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict
-
+        Returns:
+            list: A list of ethernet networks.
         """
         return self._client.get_by(field, value)
 

--- a/hpOneView/resources/networking/fabrics.py
+++ b/hpOneView/resources/networking/fabrics.py
@@ -60,8 +60,7 @@ class Fabrics(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -69,8 +68,8 @@ class Fabrics(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
 
-        Returns: dict
-
+        Returns:
+            list: A list of fabrics.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -93,7 +92,7 @@ class Fabrics(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict
-
+        Returns:
+            list: A list of fabrics.
         """
         return self._client.get_by(field, value)

--- a/hpOneView/resources/networking/fc_networks.py
+++ b/hpOneView/resources/networking/fc_networks.py
@@ -64,8 +64,7 @@ class FcNetworks(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -73,8 +72,8 @@ class FcNetworks(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
 
-        Returns: dict
-
+        Returns:
+            list: A list of Fibre Channel networks.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -151,7 +150,7 @@ class FcNetworks(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict
-
+        Returns:
+            list: A list of Fibre Channel networks.
         """
         return self._client.get_by(field, value)

--- a/hpOneView/resources/networking/fcoe_networks.py
+++ b/hpOneView/resources/networking/fcoe_networks.py
@@ -62,8 +62,7 @@ class FcoeNetworks(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -71,7 +70,8 @@ class FcoeNetworks(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
 
-        Returns: dict
+        Returns:
+            list: A list of FCoE networks.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -142,6 +142,7 @@ class FcoeNetworks(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict
+        Returns:
+            list: A list of FCoE networks.
         """
         return self._client.get_by(field, value)

--- a/hpOneView/resources/networking/interconnect_types.py
+++ b/hpOneView/resources/networking/interconnect_types.py
@@ -60,8 +60,7 @@ class InterconnectTypes(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -69,8 +68,8 @@ class InterconnectTypes(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
 
-        Returns: dict
-
+        Returns:
+            list: A list of Interconnect types.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -94,7 +93,7 @@ class InterconnectTypes(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict
-
+        Returns:
+            list: A list of Interconnect types.
         """
         return self._client.get_by(field, value)

--- a/hpOneView/resources/networking/interconnects.py
+++ b/hpOneView/resources/networking/interconnects.py
@@ -62,8 +62,7 @@ class Interconnects(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -72,8 +71,7 @@ class Interconnects(object):
                 on create time, with the oldest entry first.
 
         Returns:
-            list: A list of interconnects
-
+            list: A list of interconnects.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -144,7 +142,7 @@ class Interconnects(object):
             value: value to filter
 
         Returns:
-            list: A list of interconnects
+            list: A list of interconnects.
         """
         return self._client.get_by(field, value)
 

--- a/hpOneView/resources/networking/logical_downlinks.py
+++ b/hpOneView/resources/networking/logical_downlinks.py
@@ -58,8 +58,7 @@ class LogicalDownlinks(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -67,8 +66,8 @@ class LogicalDownlinks(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
 
-        Returns: dict
-
+        Returns:
+            list: A list of logical downlinks.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -92,8 +91,8 @@ class LogicalDownlinks(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict
-
+        Returns:
+            list: A list of logical downlinks.
         """
         return self._client.get_by(field, value)
 
@@ -109,8 +108,7 @@ class LogicalDownlinks(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.

--- a/hpOneView/resources/networking/logical_interconnect_groups.py
+++ b/hpOneView/resources/networking/logical_interconnect_groups.py
@@ -59,8 +59,7 @@ class LogicalInterconnectGroups(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -69,8 +68,7 @@ class LogicalInterconnectGroups(object):
                 on create time, with the oldest entry first.
 
         Returns:
-            list: A list of  logical interconnect groups
-
+            list: A list of logical interconnect groups.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -166,7 +164,7 @@ class LogicalInterconnectGroups(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict
-
+        Returns:
+            list: A list of Logical interconnect groups.
         """
         return self._client.get_by(field, value)

--- a/hpOneView/resources/networking/logical_interconnects.py
+++ b/hpOneView/resources/networking/logical_interconnects.py
@@ -67,8 +67,7 @@ class LogicalInterconnects(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -77,8 +76,7 @@ class LogicalInterconnects(object):
                 on create time, with the oldest entry first.
 
         Returns:
-            list: A list of logical interconnects
-
+            list: A list of logical interconnects.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 

--- a/hpOneView/resources/networking/logical_switch_groups.py
+++ b/hpOneView/resources/networking/logical_switch_groups.py
@@ -72,8 +72,7 @@ class LogicalSwitchGroups(object):
                 on create time, with the oldest entry first.
 
         Returns:
-            list: A list of  logical switch groups
-
+            list: A list of logical switch groups.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -151,7 +150,6 @@ class LogicalSwitchGroups(object):
             value: value to filter
 
         Returns:
-            list: A list of  logical switch groups that match the filter
-
+            list: A list of logical switch groups that match the filter.
         """
         return self._client.get_by(field, value)

--- a/hpOneView/resources/networking/network_sets.py
+++ b/hpOneView/resources/networking/network_sets.py
@@ -62,8 +62,7 @@ class NetworkSets(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -71,8 +70,8 @@ class NetworkSets(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
 
-        Returns: dict
-
+        Returns:
+            list: A list of Network sets.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -145,8 +144,8 @@ class NetworkSets(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict
-
+        Returns:
+            list: A list of Network sets.
         """
         return self._client.get_by(field, value)
 
@@ -162,8 +161,7 @@ class NetworkSets(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -171,8 +169,8 @@ class NetworkSets(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
 
-        Returns: dict
-
+        Returns:
+            list: A list of network sets without ethernet.
         """
         without_ethernet_client = ResourceClient(
             self._connection, "/rest/network-sets/withoutEthernet")

--- a/hpOneView/resources/networking/switch_types.py
+++ b/hpOneView/resources/networking/switch_types.py
@@ -60,8 +60,7 @@ class SwitchTypes(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -69,8 +68,8 @@ class SwitchTypes(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
 
-        Returns: dict
-
+        Returns:
+            list: A list of switch types.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -93,7 +92,7 @@ class SwitchTypes(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict
-
+        Returns:
+            list: A list of switch types.
         """
         return self._client.get_by(field, value)

--- a/hpOneView/resources/networking/switches.py
+++ b/hpOneView/resources/networking/switches.py
@@ -74,8 +74,7 @@ class Switches(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -84,8 +83,7 @@ class Switches(object):
                 on create time, with the oldest entry first.
 
         Returns:
-            list: A list of rack switches
-
+            list: A list of rack switches.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -141,7 +139,7 @@ class Switches(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict
-
+        Returns:
+            list: A list of rack switches.
         """
         return self._client.get_by(field, value)

--- a/hpOneView/resources/networking/uplink_sets.py
+++ b/hpOneView/resources/networking/uplink_sets.py
@@ -67,8 +67,7 @@ class UplinkSets(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -76,8 +75,8 @@ class UplinkSets(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
 
-        Returns: dict
-
+        Returns:
+            list: A list of uplink sets.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 

--- a/hpOneView/resources/servers/connections.py
+++ b/hpOneView/resources/servers/connections.py
@@ -59,8 +59,7 @@ class Connections(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -74,8 +73,8 @@ class Connections(object):
                  specifying the name of a predefined view. The default view is expand - show
                  all attributes of the resource and all elements of collections of resources.
 
-        Returns: dict
-
+        Returns:
+            list: A list of connections.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort, view=view, fields=fields)
 
@@ -88,8 +87,8 @@ class Connections(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict
-
+        Returns:
+            list: A list of connections.
         """
         return self._client.get_by(field, value)
 

--- a/hpOneView/resources/servers/enclosure_groups.py
+++ b/hpOneView/resources/servers/enclosure_groups.py
@@ -59,8 +59,7 @@ class EnclosureGroups(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -69,8 +68,7 @@ class EnclosureGroups(object):
                 on create time, with the oldest entry first.
 
         Returns:
-            list: A list of enclosure groups
-
+            list: A list of enclosure groups.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -106,8 +104,8 @@ class EnclosureGroups(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict
-
+        Returns:
+            list: A list of enclosure groups.
         """
         return self._client.get_by(field, value)
 

--- a/hpOneView/resources/servers/enclosures.py
+++ b/hpOneView/resources/servers/enclosures.py
@@ -58,8 +58,7 @@ class Enclosures(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -67,8 +66,8 @@ class Enclosures(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
 
-        Returns: dict
-
+        Returns:
+            list: A list of Enclosures.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -81,8 +80,8 @@ class Enclosures(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict
-
+        Returns:
+            list: A list of Enclosures.
         """
         return self._client.get_by(field, value)
 

--- a/hpOneView/resources/servers/id_pools_ranges.py
+++ b/hpOneView/resources/servers/id_pools_ranges.py
@@ -125,12 +125,13 @@ class IdPoolsRanges(object):
             count:
                  The number of resources to return. A count of -1 requests all the items. The actual number of items in
                  the response may differ from the requested count if the sum of start and count exceed the total number
-                 of items, or if returning the requested number of items would take too long.
+                 of items.
             start:
                 The first item to return, using 0-based indexing. If not specified, the default is 0 - start with the
                 first available item.
 
-        Returns: the list of IDs
+        Returns:
+            list: A list with IDs
 
         """
         uri = self._client.build_uri(id_or_uri) + \
@@ -189,7 +190,7 @@ class IdPoolsRanges(object):
             count:
                  The number of resources to return. A count of -1 requests all the items. The actual number of items in
                  the response may differ from the requested count if the sum of start and count exceed the total number
-                 of items, or if returning the requested number of items would take too long.
+                 of items.
             start:
                 The first item to return, using 0-based indexing. If not specified, the default is 0 - start with the
                 first available item.

--- a/hpOneView/resources/servers/logical_enclosures.py
+++ b/hpOneView/resources/servers/logical_enclosures.py
@@ -58,8 +58,7 @@ class LogicalEnclosures(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -67,8 +66,8 @@ class LogicalEnclosures(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
 
-        Returns: (dict) logical enclosure
-
+        Returns:
+            list: A list of logical enclosures.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -81,8 +80,8 @@ class LogicalEnclosures(object):
             field: field name to filter
             value: value to filter
 
-        Returns: (dict) logical enclosure
-
+        Returns:
+            list: A list of logical enclosures.
         """
         return self._client.get_by(field, value)
 

--- a/hpOneView/resources/servers/server_hardware.py
+++ b/hpOneView/resources/servers/server_hardware.py
@@ -141,8 +141,7 @@ class ServerHardware(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -151,8 +150,7 @@ class ServerHardware(object):
                 on create time, with the oldest entry first.
 
         Returns:
-            list: A list of server hardware resources
-
+            list: A list of server hardware resources.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 

--- a/hpOneView/resources/servers/server_hardware_types.py
+++ b/hpOneView/resources/servers/server_hardware_types.py
@@ -56,8 +56,7 @@ class ServerHardwareTypes(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -65,8 +64,8 @@ class ServerHardwareTypes(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
 
-        Returns: dict
-
+        Returns:
+            list: A list of server hardware type.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -126,7 +125,7 @@ class ServerHardwareTypes(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict
-
+        Returns:
+            list: A list of server hardware type.
         """
         return self._client.get_by(field, value)

--- a/hpOneView/resources/servers/server_profile_templates.py
+++ b/hpOneView/resources/servers/server_profile_templates.py
@@ -75,7 +75,7 @@ class ServerProfileTemplate(object):
                 on create time, with the oldest entry first.
 
         Returns:
-            list: A list of server profile templates
+            list: A list of server profile templates.
 
         """
         return self._client.get_all(start=start, count=count, filter=filter, sort=sort)

--- a/hpOneView/resources/settings/firmware_drivers.py
+++ b/hpOneView/resources/settings/firmware_drivers.py
@@ -49,7 +49,7 @@ class FirmwareDrivers(object):
 
     def get_all(self, start=0, count=-1, filter='', sort=''):
         """
-        Gets a paginated collection of Enclosures. The collection is based on optional sorting and filtering, and
+        Gets a paginated collection of Firware Drivers. The collection is based on optional sorting and filtering, and
         constrained by start and count parameters.
 
         Args:
@@ -59,8 +59,7 @@ class FirmwareDrivers(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -69,8 +68,7 @@ class FirmwareDrivers(object):
                 on create time, with the oldest entry first.
 
         Returns:
-            list: list of firmware baseline resources
-
+            list: list of firmware baseline resources.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -85,8 +83,7 @@ class FirmwareDrivers(object):
             value: value to filter
 
         Returns:
-            list: list of firmware baseline resources
-
+            list: list of firmware baseline resources.
         """
         firmwares = self.get_all()
         matches = []

--- a/hpOneView/resources/storage/storage_pools.py
+++ b/hpOneView/resources/storage/storage_pools.py
@@ -60,8 +60,7 @@ class StoragePools(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -70,7 +69,7 @@ class StoragePools(object):
                 on create time, with the oldest entry first.
 
         Returns:
-            list: A list of storage pools
+            list: A list of storage pools.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -128,7 +127,7 @@ class StoragePools(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict of storage pools
-
+        Returns:
+            list: A list of storage pools.
         """
         return self._client.get_by(field, value)

--- a/hpOneView/resources/storage/storage_systems.py
+++ b/hpOneView/resources/storage/storage_systems.py
@@ -60,8 +60,7 @@ class StorageSystems(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -70,7 +69,7 @@ class StorageSystems(object):
                 on create time, with the oldest entry first.
 
         Returns:
-            list: A list of all managed storage systems
+            list: A list of all managed storage systems.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -195,8 +194,8 @@ class StorageSystems(object):
             field: field name to filter
             value: value to filter
 
-        Returns: dict of storage systems
-
+        Returns:
+            list: A list of storage systems.
         """
         return self._client.get_by(field, value)
 

--- a/hpOneView/resources/storage/storage_volume_attachments.py
+++ b/hpOneView/resources/storage/storage_volume_attachments.py
@@ -57,8 +57,7 @@ class StorageVolumeAttachments(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -66,7 +65,7 @@ class StorageVolumeAttachments(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
         Returns:
-            list: volume attachment resources
+            list: Volume attachment resources.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -81,8 +80,7 @@ class StorageVolumeAttachments(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -147,6 +145,7 @@ class StorageVolumeAttachments(object):
         Args:
             field: field name to filter
             value: value to filter
-        Returns: dict of volume attachments
+        Returns:
+            list: List of volume attachments.
         """
         return self._client.get_by(field, value)

--- a/hpOneView/resources/storage/storage_volume_templates.py
+++ b/hpOneView/resources/storage/storage_volume_templates.py
@@ -57,8 +57,7 @@ class StorageVolumeTemplates(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -66,7 +65,7 @@ class StorageVolumeTemplates(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
         Returns:
-            list: A list of storage volume templates
+            list: A list of storage volume templates.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -144,6 +143,6 @@ class StorageVolumeTemplates(object):
             field: field name to filter
             value: value to filter
         Returns:
-            list: A list of storage volume templates that match the filter
+            list: A list of storage volume templates that match the filter.
         """
         return self._client.get_by(field, value)

--- a/hpOneView/resources/storage/volumes.py
+++ b/hpOneView/resources/storage/volumes.py
@@ -64,8 +64,7 @@ class Volumes(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.
@@ -74,7 +73,7 @@ class Volumes(object):
                 on create time, with the oldest entry first.
 
         Returns:
-            list: A list of volumes.
+            list: A list of managed volumes.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -99,7 +98,7 @@ class Volumes(object):
             value: Value to filter.
 
         Returns:
-            dict: A list of volumes.
+            list: A list of managed volumes.
         """
         return self._client.get_by(field, value)
 
@@ -177,8 +176,7 @@ class Volumes(object):
             count:
                 The number of resources to return. A count of -1 requests all the items.
                 The actual number of items in the response may differ from the requested
-                count if the sum of start and count exceed the total number of items, or
-                if returning the requested number of items would take too long.
+                count if the sum of start and count exceed the total number of items.
             filter:
                 A general filter/query string to narrow the list of items returned. The
                 default is no filter - all resources are returned.

--- a/hpOneView/resources/storage/volumes.py
+++ b/hpOneView/resources/storage/volumes.py
@@ -73,8 +73,8 @@ class Volumes(object):
                 The sort order of the returned data set. By default, the sort order is based
                 on create time, with the oldest entry first.
 
-        Returns: A list of volumes.
-
+        Returns:
+            list: A list of volumes.
         """
         return self._client.get_all(start, count, filter=filter, sort=sort)
 
@@ -98,8 +98,8 @@ class Volumes(object):
             field: Field name to filter.
             value: Value to filter.
 
-        Returns: A list of volumes.
-
+        Returns:
+            dict: A list of volumes.
         """
         return self._client.get_by(field, value)
 
@@ -108,6 +108,8 @@ class Volumes(object):
         Creates or adds a volume.
 
         It's possible to create the volume in 6 different ways:
+
+          It's possible to create the volume in 6 different ways:
 
           1) Common = Storage System + Storage Pool
           2) Template = Storage Volume Template
@@ -124,8 +126,8 @@ class Volumes(object):
                 Timeout in seconds. Wait task completion by default. The timeout does not abort the operation
                 in OneView, just stop waiting for its completion.
 
-        Returns: Created or added resource.
-
+        Returns:
+            dict: Created or added resource.
         """
         return self._client.create(resource, timeout=timeout)
 


### PR DESCRIPTION
We are changing the get_all on the ResourceClient to support all types of resources.

More than one request can be send to get all the items, regardless the query parameter count.

On the OneView Rest API, the actual number of items in the response may differ from the requested count. Some types of resource has a limited number of items returned on each call when the requested count is -1 (default). For those resources, additional calls are made to the API to retrieve any other items matching the given filter. The actual number of items can also diverge from the requested call if the requested number of items would take too long

It also has a minor fix for logical interconnects, found while I was executing the example to validate the solution.
