### PR TITLE
Fix: Delete an interconnect at a specified location

### DIFF
--- a/hpOneView/resources/networking/logical_interconnects.py
+++ b/hpOneView/resources/networking/logical_interconnects.py
@@ -336,9 +336,9 @@ class LogicalInterconnects(object):
 
         Returns: bool: indicating if the interconnect was successfully deleted.
         """
-        uri = "{locations_uri}?location=Enclosure:{enclosure_uri},Bay:{bay}".format(locations_uri=self.locations_uri,
-                                                                                    enclosure_uri=enclosure_uri,
-                                                                                    bay=bay)
+        uri = "{path}?location=Enclosure:{enclosure_uri},Bay:{bay}".format(path=self.LOCATIONS_PATH,
+                                                                           enclosure_uri=enclosure_uri,
+                                                                           bay=bay)
         return self._client.delete(uri, timeout=timeout)
 
     def get_firmware(self, id_or_uri):

--- a/tests/unit/resources/networking/test_logical_interconnects.py
+++ b/tests/unit/resources/networking/test_logical_interconnects.py
@@ -453,8 +453,7 @@ class LogicalInterconnectsTest(unittest.TestCase):
         self._logical_interconnect.delete_interconnect(enclosure_uri="/rest/enclosures/09SGH100X6J1",
                                                        bay=3, timeout=-1)
 
-        expected_uri = "/rest/logical-interconnects/locations/interconnects" \
-                       "?location=Enclosure:/rest/enclosures/09SGH100X6J1,Bay:3"
+        expected_uri = "/locations/interconnects?location=Enclosure:/rest/enclosures/09SGH100X6J1,Bay:3"
         mock_delete.assert_called_once_with(expected_uri, timeout=-1)
 
     @mock.patch.object(ResourceClient, 'build_uri')


### PR DESCRIPTION
This changes will fix a bug found due to a recent improvement made in the connection class.

Before the merge of the PR #120, the error handling of the delete function was not working properly for a 404 response, masking the error when the requested url was wrong.