### PR TITLE
Making drive name a required parameter for make_local_storage_dict

### DIFF
--- a/examples/scripts/define-profile.py
+++ b/examples/scripts/define-profile.py
@@ -324,6 +324,9 @@ def main():
     targets in the UEFI Boot Order list will not be modified, and any new
     network boot targets will be added to the end of the list using the
     System ROM's default policy.''')
+    parser.add_argument('-dn', dest='driveName', required=False,
+                        help='''
+        The name of the logical drive.''')
     parser.add_argument('-rl', dest='raidlevel', required=False,
                         choices=['NONE', 'RAID0', 'RAID1'],
                         help='''
@@ -428,7 +431,7 @@ def main():
 
     fw_settings = profile.make_firmware_dict(sts, args.baseline)
     local_storage = profile.make_local_storage_dict(sht, args.raidlevel, args.lboot,
-                            args.init_storage, args.physnum)
+                            args.init_storage, args.physnum, args.driveName)
     bios = profile.make_bios_dict(args.bios_list)
     define_profile(con, srv, args.affinity, args.name, args.desc, server, sht,
                    boot, bootmode, fw_settings, args.hide_flexnics,

--- a/hpOneView/profile.py
+++ b/hpOneView/profile.py
@@ -81,7 +81,7 @@ def make_firmware_dict(settings, baseline):
     return fw_settings
 
 
-def make_local_storage_dict(sht, raidlevel, lboot, init_storage, num):
+def make_local_storage_dict(sht, raidlevel, lboot, init_storage, num, drive_name):
     """
     Create a local storage dictionary for use in defining either a server
     profile or server profile template.
@@ -103,7 +103,7 @@ def make_local_storage_dict(sht, raidlevel, lboot, init_storage, num):
 
         drives = []
         drives.append(make_LogicalDriveV3(bootable=lboot,
-                                          driveName=None,
+                                          driveName=drive_name,
                                           driveTechnology=None,
                                           numPhysicalDrives=num,
                                           raidLevel=raidlevel))

--- a/tests/unit/test_profile.py
+++ b/tests/unit/test_profile.py
@@ -81,19 +81,20 @@ class ProfilesTest(unittest.TestCase):
     def test_make_local_storage_with_bl(self):
         sht = self.build_gen8_bl_sht()
         local_storage = self.profile.make_local_storage_dict(
-            sht, 'RAID0', False, False, 2)
+            sht, 'RAID0', False, False, 2, 'Operating System')
         self.assertIsNotNone(local_storage)
         self.assertEqual(
             {'controllers': [{'slotNumber': '0', 'logicalDrives': [
-                             {'driveTechnology': None, 'driveName': None, 'raidLevel': 'RAID0', 'bootable': False,
-                              'numPhysicalDrives': 2}], 'importConfiguration': True, 'mode': 'RAID',
-                'initialize': False, 'managed': True}]},
+                             {'driveTechnology': None, 'driveName': 'Operating System', 'raidLevel': 'RAID0',
+                              'bootable': False, 'numPhysicalDrives': 2}], 'importConfiguration': True,
+                'mode': 'RAID', 'initialize': False, 'managed': True}]},
             local_storage)
 
     def test_make_local_storage_with_dl(self):
         sht = self.build_dl_sht()
         try:
-            self.profile.make_local_storage_dict(sht, 'RAID0', False, False, 2)
+            self.profile.make_local_storage_dict(
+                sht, 'RAID0', False, False, 2, 'Operating System')
         except HPOneViewInvalidResource as hp_exception:
             self.assertEqual(
                 hp_exception.args[0], 'Local storage management is not supported on DL servers')
@@ -104,7 +105,8 @@ class ProfilesTest(unittest.TestCase):
         sht = self.build_gen8_bl_sht()
         sht.pop('model', None)
         try:
-            self.profile.make_local_storage_dict(sht, 'RAID0', False, False, 2)
+            self.profile.make_local_storage_dict(
+                sht, 'RAID0', False, False, 2, 'Operating System')
         except HPOneViewInvalidResource as hp_exception:
             self.assertEqual(
                 hp_exception.args[0], 'Error, can not retrieve server model')


### PR DESCRIPTION
function.

Updated example and tests.

Related to issue https://github.com/HewlettPackard/python-hpOneView/issues/28