### PR TITLE
Add support to alerts

### DIFF
--- a/examples/alerts.py
+++ b/examples/alerts.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+###
+# (C) Copyright (2012-2016) Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+###
+
+from hpOneView.oneview_client import OneViewClient
+from config_loader import try_load_from_file
+from hpOneView import extract_id_from_uri
+
+config = {
+    "ip": "172.16.102.59",
+    "credentials": {
+        "userName": "administrator",
+        "password": ""
+    }
+}
+
+# Try load config from a file (if there is a config file)
+config = try_load_from_file(config)
+
+_client = OneViewClient(config)
+
+# Getting the first 5 alerts
+print("\nGetting the first 5 alerts")
+alerts = _client.alerts.get_all(0, 5)
+for alert in alerts:
+    print("uri: '%s' | type: '%s' | alertState: '%s'" % (alert['uri'], alert['type'], alert['alertState']))
+
+# Get a specific alert (first of the list that was obtained in previous item)
+print("\nGet a specific alert")
+id_alert_by_id = extract_id_from_uri(alerts[0]['uri'])
+print("Find id == %s" % id_alert_by_id)
+alert_by_id = _client.alerts.get(id_alert_by_id)
+print("uri: '%s' | alertState: '%s'" % (alert_by_id['uri'], alert_by_id['alertState']))
+
+# Get by Uri
+print("Find uri == %s" % (alert['uri']))
+alert_by_uri = _client.alerts.get(alert['uri'])
+print("uri: '%s' | alertState: '%s'" % (alert_by_uri['uri'], alert_by_uri['alertState']))
+
+# Find first alert by state
+print("\nGet first alert by state: Active")
+alert_by_state = _client.alerts.get_by('alertState', 'Active')[0]
+print("Found alert by state: '%s' | uri: '%s'" % (alert_by_state["alertState"], alert_by_state["uri"]))
+
+# Update state alert
+print("\nUpdate state alert")
+alert_to_update = {
+    'uri': alert_by_state['uri'],
+    'alertState': 'Cleared',
+}
+alert_updated = _client.alerts.update(alert_to_update)
+print("Update alert successfully.\n uri = '%s' | alertState = '%s'" %
+      (alert_updated['uri'], alert_updated['alertState']))
+
+# Filter by state
+print("\nGet all alerts filtering by alertState")
+alerts = _client.alerts.get_all(filter="\"alertState='Locked'\"", view="day", count=10)
+for alert in alerts:
+    print("'%s' | type: '%s' | alertState: '%s'" % (alert['uri'], alert['type'], alert['alertState']))
+
+# Delete the alert
+print("\nDelete an alert")
+_client.alerts.delete(alert_by_id)
+print("Successfully deleted alert")
+
+# # Deletes the AlertChangeLog item identified by ID
+# print("Deletes alert change log")
+# _client.alerts.delete_alert_change_log('8')

--- a/examples/alerts.py
+++ b/examples/alerts.py
@@ -24,6 +24,7 @@
 from hpOneView.oneview_client import OneViewClient
 from config_loader import try_load_from_file
 from hpOneView import extract_id_from_uri
+from pprint import pprint
 
 config = {
     "ip": "172.16.102.59",
@@ -42,7 +43,7 @@ _client = OneViewClient(config)
 print("\nGetting the first 5 alerts")
 alerts = _client.alerts.get_all(0, 5)
 for alert in alerts:
-    print("uri: '%s' | type: '%s' | alertState: '%s'" % (alert['uri'], alert['type'], alert['alertState']))
+    "uri: '{uri}' | type: '{type}' | alertState: '{alertState}'".format(**alert)
 
 # Get a specific alert (first of the list that was obtained in previous item)
 print("\nGet a specific alert")
@@ -62,7 +63,7 @@ alert_by_state = _client.alerts.get_by('alertState', 'Cleared')[0]
 print("Found alert by state: '%s' | uri: '%s'" % (alert_by_state['alertState'], alert_by_state['uri']))
 
 # Updates state alert and add note
-print("\nUpdate state alert and add an note")
+print("\nUpdate state alert and add a note")
 alert_to_update = {
     'uri': alert_by_state['uri'],
     'alertState': 'Active',
@@ -70,8 +71,8 @@ alert_to_update = {
 }
 alert_updated = _client.alerts.update(alert_to_update)
 print("uri = '%s' | alertState = '%s'" % (alert_by_state['uri'], alert_by_state['alertState']))
-print("Update alert successfully.\nuri = '%s' | alertState = '%s'" %
-      (alert_updated['uri'], alert_updated['alertState']))
+print("Update alert successfully.")
+pprint(alert_updated)
 
 # Filter by state
 print("\nGet all alerts filtering by alertState")

--- a/examples/alerts.py
+++ b/examples/alerts.py
@@ -57,18 +57,20 @@ alert_by_uri = _client.alerts.get(alert['uri'])
 print("uri: '%s' | alertState: '%s'" % (alert_by_uri['uri'], alert_by_uri['alertState']))
 
 # Find first alert by state
-print("\nGet first alert by state: Active")
-alert_by_state = _client.alerts.get_by('alertState', 'Active')[0]
-print("Found alert by state: '%s' | uri: '%s'" % (alert_by_state["alertState"], alert_by_state["uri"]))
+print("\nGet first alert by state: Cleared")
+alert_by_state = _client.alerts.get_by('alertState', 'Cleared')[0]
+print("Found alert by state: '%s' | uri: '%s'" % (alert_by_state['alertState'], alert_by_state['uri']))
 
-# Update state alert
-print("\nUpdate state alert")
+# Updates state alert and add note
+print("\nUpdate state alert and add an note")
 alert_to_update = {
     'uri': alert_by_state['uri'],
-    'alertState': 'Cleared',
+    'alertState': 'Active',
+    'notes': 'A note to delete!'
 }
 alert_updated = _client.alerts.update(alert_to_update)
-print("Update alert successfully.\n uri = '%s' | alertState = '%s'" %
+print("uri = '%s' | alertState = '%s'" % (alert_by_state['uri'], alert_by_state['alertState']))
+print("Update alert successfully.\nuri = '%s' | alertState = '%s'" %
       (alert_updated['uri'], alert_updated['alertState']))
 
 # Filter by state
@@ -77,11 +79,15 @@ alerts = _client.alerts.get_all(filter="\"alertState='Locked'\"", view="day", co
 for alert in alerts:
     print("'%s' | type: '%s' | alertState: '%s'" % (alert['uri'], alert['type'], alert['alertState']))
 
-# Delete the alert
+# Deletes the alert
 print("\nDelete an alert")
 _client.alerts.delete(alert_by_id)
 print("Successfully deleted alert")
 
-# # Deletes the AlertChangeLog item identified by ID
-# print("Deletes alert change log")
-# _client.alerts.delete_alert_change_log('8')
+# Deletes the AlertChangeLog item identified by URI
+print("\nDelete alert change log by URI")
+# filter by user entered logs
+list_change_logs = [x for x in alert_updated['changeLog'] if x['userEntered'] is True]
+uri_note = list_change_logs[-1]['uri']
+_client.alerts.delete_alert_change_log(uri_note)
+print("Note with URI '%s' deleted" % uri_note)

--- a/hpOneView/activity.py
+++ b/hpOneView/activity.py
@@ -61,7 +61,9 @@ def deprecated(func):
     def wrapper(*args, **kwargs):
         warn("Module activity is deprecated, use OneViewClient class instead", DeprecationWarning, stacklevel=2)
         return func(*args, **kwargs)
+
     return wrapper
+
 
 TaskErrorStates = ['Error', 'Warning', 'Terminated', 'Killed']
 TaskCompletedStates = ['Error', 'Warning', 'Completed', 'Terminated', 'Killed']

--- a/hpOneView/common.py
+++ b/hpOneView/common.py
@@ -1827,3 +1827,19 @@ def transform_list_to_dict(list):
             ret[str(value)] = True
 
     return ret
+
+
+def extract_id_from_uri(id_or_uri):
+    """
+    Extract ID from the end of the URI
+
+    Args:
+        id_or_uri: ID or URI of the OneView resources.
+
+    Returns:
+        str: The string founded after the last "/"
+    """
+    if '/' in id_or_uri:
+        return id_or_uri[id_or_uri.rindex('/') + 1:]
+    else:
+        return id_or_uri

--- a/hpOneView/oneview_client.py
+++ b/hpOneView/oneview_client.py
@@ -92,6 +92,7 @@ from hpOneView.resources.storage.volumes import Volumes
 from hpOneView.resources.networking.uplink_sets import UplinkSets
 from hpOneView.resources.servers.migratable_vc_domains import MigratableVcDomains
 from hpOneView.resources.search.labels import Labels
+from hpOneView.resources.activity.alerts import Alerts
 
 ONEVIEW_CLIENT_INVALID_PROXY = 'Invalid Proxy format'
 
@@ -150,6 +151,7 @@ class OneViewClient(object):
         self.__managed_sans = None
         self.__migratable_vc_domains = None
         self.__labels = None
+        self.__alerts = None
         # TODO: Implement: con.set_trusted_ssl_bundle(args.cert)
 
     @classmethod
@@ -779,3 +781,15 @@ class OneViewClient(object):
         if not self.__labels:
             self.__labels = Labels(self.__connection)
         return self.__labels
+
+    @property
+    def alerts(self):
+        """
+        Gets the Alerts API client.
+
+        Returns:
+            Alerts:
+        """
+        if not self.__alerts:
+            self.__alerts = Alerts(self.__connection)
+        return self.__alerts

--- a/hpOneView/resources/activity/alerts.py
+++ b/hpOneView/resources/activity/alerts.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+###
+# (C) Copyright (2012-2016) Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+###
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from future import standard_library
+
+standard_library.install_aliases()
+
+__title__ = 'Tasks'
+__version__ = '0.0.1'
+__copyright__ = '(C) Copyright (2012-2016) Hewlett Packard Enterprise ' \
+                ' Development LP'
+__license__ = 'MIT'
+__status__ = 'Development'
+
+from hpOneView.resources.resource import ResourceClient
+from hpOneView import extract_id_from_uri
+
+
+class Alerts(object):
+    URI = '/rest/alerts'
+
+    def __init__(self, con):
+        self._connection = con
+        self._client = ResourceClient(con, self.URI)
+
+    def get(self, id_or_uri):
+        """
+        Retrieve an alert by its URI or ID.
+
+        Args:
+            id_or_uri: alert ID or URI.
+
+        Returns:
+            dict: The alert.
+
+        """
+
+        alert = self._client.get(id_or_uri)
+        return alert
+
+    def get_all(self, start=0, count=-1, filter='', query='', sort='', view=''):
+        """
+        Gets all the alerts based upon filters provided.
+
+        Args:
+            start:
+                 The first item to return, using 0-based indexing. If not specified, the default is 0 - start with the
+                 first available item.
+            count:
+                The number of resources to return. A count of -1 requests all items. The actual number of items in
+                the response may differ from the requested count if the sum of start and count exceed the total number
+                of items.
+            filter (list or str):
+                 A general filter/query string to narrow the list of items returned. The default is no filter; all
+                 resources are returned.
+            query:
+                 A general query string to narrow the list of resources returned. The default is no query (all
+                 resources are returned).
+            sort:
+                The sort order of the returned data set. By default, the sort order is based on create time, with the
+                oldest entry first.
+            view:
+                 Returns a specific subset of the attributes of the resource or collection, by specifying the name of a
+                 predefined view. The default view is expand (show all attributes of the resource and all elements of
+                 collections of resources).
+
+        Returns:
+            list: A list of alerts.
+        """
+        return self._client.get_all(start=start, count=count, filter=filter, query=query, sort=sort, view=view)
+
+    def get_by(self, field, value):
+        """
+        Gets all alerts that match the filter.
+
+        The search is case-insensitive.
+
+        Args:
+            field: Field name to filter.
+            value: Value to filter.
+
+        Returns:
+            list: List of alerts.
+
+        """
+        return self._client.get_by(field, value)
+
+    def delete(self, resource):
+        """
+        Deletes an alert.
+
+        Args:
+            resource: dict object to delete
+
+        Returns:
+            bool: Indicates if the resource was successfully deleted.
+
+        """
+        return self._client.delete(resource)
+
+    def delete_all(self, filter, timeout=-1):
+        """
+        Deletes all Alert objects from the appliance that match the provided filter.
+
+        Args:
+            filter (dict): Object to delete.
+            timeout: Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
+                in OneView; it just stops waiting for its completion.
+
+        Returns:
+            bool: Indicates whether the alerts were successfully deleted.
+        """
+        return self._client.delete_all(filter=filter, timeout=timeout)
+
+    def update(self, resource, id_or_uri=None, timeout=-1):
+        """
+        Updates the specified alert resource.
+
+        Args:
+            resource (dict): Object to update.
+            timeout: Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
+                in OneView; it just stops waiting for its completion.
+
+        Returns:
+            dict: Updated alert.
+        """
+        uri = resource.pop('uri', None)
+        if not uri:
+            if not id_or_uri:
+                raise ValueError("URI was not provided")
+            uri = self._client.build_uri(id_or_uri)
+        return self._client.update(resource=resource, uri=uri, timeout=timeout)
+
+    def delete_alert_change_log(self, id_or_uri):
+        """
+        Deletes alert change log by alert ID or URI.
+
+        Args:
+            id_or_uri: alert ID or URI.
+        """
+        uri = self.URI + "/AlertChangeLog/" + extract_id_from_uri(id_or_uri)
+        resource = {
+            "uri": uri
+        }
+        self._client.delete(resource)

--- a/hpOneView/resources/activity/alerts.py
+++ b/hpOneView/resources/activity/alerts.py
@@ -30,7 +30,7 @@ from future import standard_library
 
 standard_library.install_aliases()
 
-__title__ = 'Tasks'
+__title__ = 'Alerts'
 __version__ = '0.0.1'
 __copyright__ = '(C) Copyright (2012-2016) Hewlett Packard Enterprise ' \
                 ' Development LP'

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -398,7 +398,7 @@ class ResourceClient(object):
         logger.debug('Get by (uri = %s, field = %s, value = %s)' %
                      (uri, field, str(value)))
 
-        filter = "\"'{0}'='{1}'\"".format(field, value)
+        filter = "\"{0}='{1}'\"".format(field, value)
         return self.get_all(filter=filter, uri=uri)
 
     def get_by_name(self, name):

--- a/tests/unit/resources/activity/test_alerts.py
+++ b/tests/unit/resources/activity/test_alerts.py
@@ -95,12 +95,19 @@ class AlertsTest(TestCase):
 
     @mock.patch.object(ResourceClient, 'delete')
     def test_delete_called_once(self, mock_delete):
-        id = '35323930-4936-4450-5531-303153474820'
-        self._client.delete(id)
-        mock_delete.assert_called_once_with(id)
+        id_alert = '35323930-4936-4450-5531-303153474820'
+        self._client.delete(id_alert)
+        mock_delete.assert_called_once_with(id_alert)
 
     @mock.patch.object(ResourceClient, 'delete')
-    def test_delete_alert_change_log_called_once(self, mock_delete):
-        id = '35323930-4936-4450-5531-303153474820'
-        self._client.delete_alert_change_log(id)
-        mock_delete.assert_called_once_with({'uri': '/rest/alerts/AlertChangeLog/35323930-4936-4450-5531-303153474820'})
+    def test_delete_alert_change_log_called_once_by_id(self, mock_delete):
+        id_alert = '20'
+        self._client.delete_alert_change_log(id_alert)
+        mock_delete.assert_called_once_with({'uri': '/rest/alerts/AlertChangeLog/20'})
+
+    @mock.patch.object(ResourceClient, 'delete')
+    def test_delete_alert_change_log_called_once_by_uri(self, mock_delete):
+        uri = '/rest/alerts/AlertChangeLog/20'
+        self._client.delete_alert_change_log(uri)
+        mock_delete.assert_called_once_with(
+            {'uri': uri})

--- a/tests/unit/resources/activity/test_alerts.py
+++ b/tests/unit/resources/activity/test_alerts.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+###
+# (C) Copyright (2012-2016) Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the 'Software'), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+###
+
+from unittest import TestCase
+
+import mock
+
+from hpOneView.connection import connection
+from hpOneView.resources.activity.alerts import Alerts
+from hpOneView.resources.resource import ResourceClient
+
+
+class AlertsTest(TestCase):
+    def setUp(self):
+        self.host = '127.0.0.1'
+        self.connection = connection(self.host)
+        self._client = Alerts(self.connection)
+
+    @mock.patch.object(ResourceClient, 'get_all')
+    def test_get_all(self, mock_get):
+        self._client.get_all(filter="name='name'",
+                             sort='name:ascending',
+                             view='day')
+        mock_get.assert_called_once_with(count=-1,
+                                         filter="name='name'",
+                                         query='', sort='name:ascending', start=0, view='day')
+
+    @mock.patch.object(ResourceClient, 'get')
+    def test_get_specific(self, mock_get):
+        self._client.get('35323930-4936-4450-5531-303153474820')
+        mock_get.assert_called_once_with('35323930-4936-4450-5531-303153474820')
+
+    @mock.patch.object(ResourceClient, 'get_by')
+    def test_get_by_called_once(self, mock_get_by):
+        self._client.get_by('alertState', 'Active')
+        mock_get_by.assert_called_once_with('alertState', 'Active')
+
+    @mock.patch.object(ResourceClient, 'update')
+    def test_update_should_fail_when_no_uri_is_provided(self, mock_update):
+        resource = {
+            'alertState': 'Cleared',
+            'assignedToUser': 'Paul',
+            'alertUrgency': 'None',
+            'notes': 'Problem fixed',
+            'eTag': '2014-03-28T04:40:06.831Z'
+        }
+        self.assertRaises(ValueError, self._client.update, resource)
+
+    @mock.patch.object(ResourceClient, 'update')
+    def test_update_should_use_given_values_by_resource_uri(self, mock_update):
+        resource = {
+            'uri': '/rest/alerts/26',
+            'alertState': 'Cleared',
+            'assignedToUser': 'Paul',
+            'alertUrgency': 'None',
+            'notes': 'Problem fixed',
+            'eTag': '2014-03-28T04:40:06.831Z'
+        }
+        self._client.update(resource.copy(), '/rest/alerts/26')
+        resource_test = resource.copy()
+        del resource_test["uri"]
+        mock_update.assert_called_once_with(resource=resource_test, timeout=-1, uri='/rest/alerts/26')
+
+    @mock.patch.object(ResourceClient, 'update')
+    def test_update_should_use_given_values_by_uri_param(self, mock_update):
+        resource = {
+            'alertState': 'Cleared',
+            'assignedToUser': 'Paul',
+            'alertUrgency': 'None',
+            'notes': 'Problem fixed',
+            'eTag': '2014-03-28T04:40:06.831Z'
+        }
+        self._client.update(resource, '/rest/alerts/26')
+        mock_update.assert_called_once_with(resource=resource.copy(), timeout=-1, uri='/rest/alerts/26')
+
+    @mock.patch.object(ResourceClient, 'delete')
+    def test_delete_called_once(self, mock_delete):
+        id = '35323930-4936-4450-5531-303153474820'
+        self._client.delete(id)
+        mock_delete.assert_called_once_with(id)
+
+    @mock.patch.object(ResourceClient, 'delete')
+    def test_delete_alert_change_log_called_once(self, mock_delete):
+        id = '35323930-4936-4450-5531-303153474820'
+        self._client.delete_alert_change_log(id)
+        mock_delete.assert_called_once_with({'uri': '/rest/alerts/AlertChangeLog/35323930-4936-4450-5531-303153474820'})

--- a/tests/unit/resources/test_resource.py
+++ b/tests/unit/resources/test_resource.py
@@ -341,12 +341,12 @@ class ResourceTest(unittest.TestCase):
     @mock.patch.object(ResourceClient, 'get_all')
     def test_get_by_property(self, mock_get_all):
         self.resource_client.get_by('name', 'MyFibreNetwork')
-        mock_get_all.assert_called_once_with(filter="\"'name'='MyFibreNetwork'\"", uri='/rest/testuri')
+        mock_get_all.assert_called_once_with(filter="\"name='MyFibreNetwork'\"", uri='/rest/testuri')
 
     @mock.patch.object(ResourceClient, 'get_all')
     def test_get_by_property_with_uri(self, mock_get_all):
         self.resource_client.get_by('name', 'MyFibreNetwork', uri='/rest/testuri/5435534/sub')
-        mock_get_all.assert_called_once_with(filter="\"'name'='MyFibreNetwork'\"", uri='/rest/testuri/5435534/sub')
+        mock_get_all.assert_called_once_with(filter="\"name='MyFibreNetwork'\"", uri='/rest/testuri/5435534/sub')
 
     @mock.patch.object(ResourceClient, 'get_all')
     def test_get_by_property_with__invalid_uri(self, mock_get_all):

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -51,6 +51,7 @@ from hpOneView.resources.storage.storage_volume_attachments import StorageVolume
 from hpOneView.resources.storage.storage_volume_templates import StorageVolumeTemplates
 from hpOneView.resources.storage.volumes import Volumes
 from hpOneView.resources.search.labels import Labels
+from hpOneView.resources.activity.alerts import Alerts
 from tests.test_utils import mock_builtin
 
 
@@ -479,3 +480,10 @@ class OneViewClientTest(unittest.TestCase):
     def test_lazy_loading_labels(self):
         labels = self._oneview.labels
         self.assertEqual(labels, self._oneview.labels)
+
+    def test_alerts_has_right_type(self):
+        self.assertIsInstance(self._oneview.alerts, Alerts)
+
+    def test_lazy_loading_alerts(self):
+        alerts = self._oneview.alerts
+        self.assertEqual(alerts, self._oneview.alerts)


### PR DESCRIPTION
This PR also fix **ResourceClient.get_by** error with some resources:
The correction was made based on this explanation in OneView API Reference:

> This parameter usually requires quoting as shown in the examples here (double quotes around the entire filter parameter, and single-quotes around the {value} field)
[source](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview2.0/cic-api/en/api-docs/current/index.html#stdparams)