### PR TITLE
Adding a second validation to get_by filter

### DIFF
--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -31,7 +31,6 @@ from future.utils import lmap
 
 standard_library.install_aliases()
 
-
 import logging
 import os
 
@@ -508,7 +507,14 @@ class ResourceClient(object):
                      (uri, field, str(value)))
 
         filter = "\"{0}='{1}'\"".format(field, value)
-        return self.get_all(filter=filter, uri=uri)
+        results = self.get_all(filter=filter, uri=uri)
+
+        # Workaround when the OneView filter does not work, it will filter again
+        if "." not in field:
+            # This filter only work for the first level
+            results = [item for item in results if str(item.get(field, '')).lower() == value.lower()]
+
+        return results
 
     def get_by_name(self, name):
         """

--- a/tests/unit/resources/test_resource.py
+++ b/tests/unit/resources/test_resource.py
@@ -379,6 +379,26 @@ class ResourceClientTest(unittest.TestCase):
         mock_get_all.assert_called_once_with(filter="\"name='MyFibreNetwork'\"", uri='/rest/testuri')
 
     @mock.patch.object(ResourceClient, 'get_all')
+    def test_get_by_with_incorrect_result_autofix(self, mock_get_all):
+
+        mock_get_all.return_value = [{"name": "EXpected"},
+                                     {"name": "not expected"}]
+
+        response = self.resource_client.get_by('name', 'exPEcted')
+        self.assertEqual(response, [{"name": "EXpected"}])
+        mock_get_all.assert_called_once_with(filter="\"name='exPEcted'\"", uri='/rest/testuri')
+
+    @mock.patch.object(ResourceClient, 'get_all')
+    def test_get_by_with_incorrect_result_skip_autofix(self, mock_get_all):
+
+        mock_get_all.return_value = [{"name": "expected"},
+                                     {"name": "not expected"}]
+
+        response = self.resource_client.get_by('connection.name', 'expected')
+        self.assertEqual(response, [{'name': 'expected'}, {'name': 'not expected'}])
+        mock_get_all.assert_called_once_with(filter="\"connection.name='expected'\"", uri='/rest/testuri')
+
+    @mock.patch.object(ResourceClient, 'get_all')
     def test_get_by_property_with_uri(self, mock_get_all):
         self.resource_client.get_by('name', 'MyFibreNetwork', uri='/rest/testuri/5435534/sub')
         mock_get_all.assert_called_once_with(filter="\"name='MyFibreNetwork'\"", uri='/rest/testuri/5435534/sub')


### PR DESCRIPTION
Adding a second validation to get_by, it is a workaround for special cases when the OneView ignores the passed filter.