### PR TITLE
Fix San Managers module Issue

### DIFF
--- a/hpOneView/resources/fc_sans/san_managers.py
+++ b/hpOneView/resources/fc_sans/san_managers.py
@@ -114,17 +114,18 @@ class SanManagers(object):
         uri = self._provider_client.build_uri(provider_uri_or_id) + "/device-managers"
         return self._client.create(resource=resource, uri=uri, timeout=timeout)
 
-    def get_provider_uri(self, provider_name):
+    def get_provider_uri(self, provider_display_name):
         """
         Gets uri for a specific provider.
 
         Args:
-            provider_name: Name of the provider.
+            provider_display_name: Display name of the provider.
 
         Returns:
             uri
         """
-        return self._provider_client.get_by_name(provider_name)['uri']
+        providers = self._provider_client.get_by('displayName', provider_display_name)
+        return providers[0]['uri'] if providers else None
 
     def get_default_connection_info(self, provider_name):
         """

--- a/tests/unit/resources/fc_sans/test_san_managers.py
+++ b/tests/unit/resources/fc_sans/test_san_managers.py
@@ -31,6 +31,27 @@ from hpOneView.resources.fc_sans.san_managers import SanManagers
 
 TIMEOUT = -1
 
+PROVIDERS = [
+    {
+        "uri": "/rest/fc-sans/providers/0aa1f4e1-3b5e-4233-af1a-f849dc64da69",
+        "name": "Brocade San Plugin",
+        "displayName": "Brocade Network Advisor",
+        "sanType": "Fabric"
+    },
+    {
+        "uri": "/rest/fc-sans/providers/848c191d-c995-4cd5-a7ba-e627435dd5f2",
+        "name": "Cisco San Plugin",
+        "displayName": "Cisco",
+        "sanType": "Fabric"
+    },
+    {
+        "uri": "/rest/fc-sans/providers/5c5c67f5-0f8f-4c85-a54f-f26b1f1332c7",
+        "name": "Direct Attach SAN Plugin",
+        "displayName": "HPE",
+        "sanType": "Fabric"
+    }
+]
+
 
 class SanManagersTest(TestCase):
     def setUp(self):
@@ -133,11 +154,21 @@ class SanManagersTest(TestCase):
         self.assertFalse(provider)
         mock_get_by_name.assert_called_once_with(provider_name)
 
-    @mock.patch.object(ResourceClient, 'get_by_name')
-    def test_get_provider_uri(self, mock_get_by_name):
+    @mock.patch.object(ResourceClient, 'get_all')
+    def test_get_provider_uri(self, mock_get_all):
         provider_name = "Brocade Network Advisor"
-        self._resource.get_provider_uri(provider_name)
-        mock_get_by_name.assert_called_once_with(provider_name)
+        mock_get_all.return_value = PROVIDERS
+
+        result = self._resource.get_provider_uri(provider_name)
+        self.assertEqual(result, PROVIDERS[0]['uri'])
+
+    @mock.patch.object(ResourceClient, 'get_all')
+    def test_get_provider_uri_should_return_none_when_not_found(self, mock_get_all):
+        provider_name = "Brocade Network Advisor"
+        mock_get_all.return_value = []
+
+        result = self._resource.get_provider_uri(provider_name)
+        self.assertEqual(result, None)
 
     @mock.patch.object(ResourceClient, 'update')
     def test_update(self, mock_update):


### PR DESCRIPTION
The function 'get_provider_uri' was filtering by the field 'name', but the correct field is 'displayName'