### PR TITLE
Change raise on python version < 2.7.9 to warning

### DIFF
--- a/hpOneView/__init__.py
+++ b/hpOneView/__init__.py
@@ -48,7 +48,7 @@ PYTHON_VERSION = sys.version_info[:3]
 PY2 = (PYTHON_VERSION[0] == 2)
 if PY2:
     if PYTHON_VERSION < (2, 7, 9):
-        error_message = 'Running unsupported Python version> %s, unexpected errors might occur.'
+        error_message = 'Running unsupported Python version: %s, unexpected errors might occur.'
         error_message += ' Use of Python v2.7.9+ is advised.'
         warnings.warn(error_message % '.'.join(map(str, PYTHON_VERSION)), Warning)
 elif PYTHON_VERSION < (3, 4):

--- a/hpOneView/__init__.py
+++ b/hpOneView/__init__.py
@@ -48,13 +48,13 @@ PYTHON_VERSION = sys.version_info[:3]
 PY2 = (PYTHON_VERSION[0] == 2)
 if PY2:
     if PYTHON_VERSION < (2, 7, 9):
-        error_message = 'Running unsupported Python version: %s, unexpected errors might occur.'
-        error_message += ' Use of Python v2.7.9+ is advised.'
-        warnings.warn(error_message % '.'.join(map(str, PYTHON_VERSION)), Warning)
+        warning_message = 'Running unsupported Python version: %s, unexpected errors might occur.'
+        warning_message += ' Use of Python v2.7.9+ is advised.'
+        warnings.warn(warning_message % '.'.join(map(str, PYTHON_VERSION)), Warning)
 elif PYTHON_VERSION < (3, 4):
-        error_message = 'Running unsupported Python version> %s, unexpected errors might occur.'
-        error_message += ' Use of Python v3.4+ is advised.'
-        warnings.warn(error_message % '.'.join(map(str, PYTHON_VERSION)), Warning)
+        warning_message = 'Running unsupported Python version> %s, unexpected errors might occur.'
+        warning_message += ' Use of Python v3.4+ is advised.'
+        warnings.warn(warning_message % '.'.join(map(str, PYTHON_VERSION)), Warning)
 
 from hpOneView.common import *
 from hpOneView.connection import *

--- a/hpOneView/__init__.py
+++ b/hpOneView/__init__.py
@@ -42,14 +42,19 @@ __license__ = 'MIT'
 
 
 import sys
+import warnings
 
 PYTHON_VERSION = sys.version_info[:3]
 PY2 = (PYTHON_VERSION[0] == 2)
 if PY2:
     if PYTHON_VERSION < (2, 7, 9):
-        raise Exception('Must use Python 2.7.9 or later, detected version: %s' % '.'.join(map(str, PYTHON_VERSION)))
+        error_message = 'Running unsupported Python version> %s, unexpected errors might occur.'
+        error_message += ' Use of Python v2.7.9+ is advised.'
+        warnings.warn(error_message % '.'.join(map(str, PYTHON_VERSION)), Warning)
 elif PYTHON_VERSION < (3, 4):
-    raise Exception('Must use Python 3.4 or later, detected version: %s' % '.'.join(map(str, PYTHON_VERSION)))
+        error_message = 'Running unsupported Python version> %s, unexpected errors might occur.'
+        error_message += ' Use of Python v3.4+ is advised.'
+        warnings.warn(error_message % '.'.join(map(str, PYTHON_VERSION)), Warning)
 
 from hpOneView.common import *
 from hpOneView.connection import *


### PR DESCRIPTION
Changing raise to warning as per requests. This leaves us more vulnerable to ssl and other issues, however it allows the user flexibility if running a lesser but compatible python version