### PR TITLE
Logical Enclosure API500 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Legacy code under hpOneView which was marked as deprecated has been removed. Thi
 - Firmware driver
 - Interconnect
 - Logical downlink
+- Logical enclosure
 - Logical interconnect
 - Logical interconnect group
 - Logical switch

--- a/examples/logical_enclosures.py
+++ b/examples/logical_enclosures.py
@@ -27,10 +27,10 @@ from hpOneView.exceptions import HPOneViewException
 from config_loader import try_load_from_file
 
 config = {
-    "ip": "172.16.102.59",
+    "ip": "<oneview_ip>",
     "credentials": {
-        "userName": "administrator",
-        "password": ""
+        "userName": "<username>",
+        "password": "<password>"
     }
 }
 

--- a/hpOneView/resources/servers/logical_enclosures.py
+++ b/hpOneView/resources/servers/logical_enclosures.py
@@ -182,7 +182,8 @@ class LogicalEnclosures(object):
         Returns:
             dict: Updated logical enclosure.
         """
-        return self._client.patch(id_or_uri, operation, path, value, timeout=timeout)
+        headers = {'If-Match': '*'}
+        return self._client.patch(id_or_uri, operation, path, value, timeout=timeout, custom_headers=headers)
 
     def update_configuration(self, id_or_uri, timeout=-1):
         """

--- a/tests/unit/resources/servers/test_logical_enclosures.py
+++ b/tests/unit/resources/servers/test_logical_enclosures.py
@@ -130,7 +130,7 @@ class LogicalEnclosuresTest(TestCase):
         self._logical_enclosures.patch(
             '123a53cz', 'replace', '/name', 'new_name', 1)
         mock_patch.assert_called_once_with(
-            '123a53cz', 'replace', '/name', 'new_name', timeout=1)
+            '123a53cz', 'replace', '/name', 'new_name', timeout=1, custom_headers={u'If-Match': u'*'})
 
     @mock.patch.object(ResourceClient, 'update_with_zero_body')
     def test_update_configuration_by_uri(self, mock_update_with_zero_body):


### PR DESCRIPTION
### Description
Validated endpoints against API500 and skipped etag validation for patch operations.

### Check List
  - [X] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
  - [X] Changes are documented in the CHANGELOG.
