### PR TITLE
Fixed delete from OneView only feature

### DIFF
--- a/examples/volumes_store_serv.py
+++ b/examples/volumes_store_serv.py
@@ -159,5 +159,5 @@ if oneview_client.volumes.delete(volume):
 if oneview_client.volumes.delete(volume_from_snapshot):
     print("The volume that was previously created with from Snaphsot was deleted from OneView and storage system")
 
-if managed_volume and oneview_client.volumes.delete(managed_volume, supress_device_updates=True):
+if managed_volume and oneview_client.volumes.delete(managed_volume, suppress_device_updates=True):
     print("The unamanged volume that was previously added using the name was deleted from OneView only")

--- a/hpOneView/resources/storage/volumes.py
+++ b/hpOneView/resources/storage/volumes.py
@@ -220,11 +220,15 @@ class Volumes(object):
             bool: Indicates if the volume was successfully deleted.
         """
         custom_headers = {'If-Match': '*'}
-        if suppress_device_updates is not None:
-            custom_headers['suppressDeviceUpdates'] = suppress_device_updates
-        elif export_only is not None:
-            custom_headers['exportOnly'] = export_only
-        return self._client.delete(resource, force=force, timeout=timeout, custom_headers=custom_headers)
+        if 'uri' in resource:
+            uri = resource['uri']
+        else:
+            uri = self._client.build_uri(resource)
+        if suppress_device_updates:
+            uri += '?suppressDeviceUpdates=true'
+        if export_only:
+            custom_headers['exportOnly'] = True
+        return self._client.delete(uri, force=force, timeout=timeout, custom_headers=custom_headers)
 
     def __build_volume_snapshot_uri(self, volume_id_or_uri=None, snapshot_id_or_uri=None):
         if snapshot_id_or_uri and "/" in snapshot_id_or_uri:

--- a/tests/unit/resources/storage/test_volumes.py
+++ b/tests/unit/resources/storage/test_volumes.py
@@ -109,6 +109,18 @@ class VolumesTest(unittest.TestCase):
         mock_delete.assert_called_once_with(uri, force=False, timeout=-1, custom_headers=expected_headers)
 
     @mock.patch.object(ResourceClient, 'delete')
+    def test_delete_by_resource_called_once(self, mock_delete):
+        resource = {
+            'uri': '/rest/storage-volumes/fake',
+            'name': 'VOLUME_FAKE'
+        }
+        uri = '/rest/storage-volumes/fake'
+        self._volumes.delete(resource, force=False, timeout=-1)
+
+        expected_headers = {"If-Match": '*'}
+        mock_delete.assert_called_once_with(uri, force=False, timeout=-1, custom_headers=expected_headers)
+
+    @mock.patch.object(ResourceClient, 'delete')
     def test_delete_with_force_called_once(self, mock_delete):
         uri = '/rest/storage-volumes/fake'
         self._volumes.delete(uri, force=True)

--- a/tests/unit/resources/storage/test_volumes.py
+++ b/tests/unit/resources/storage/test_volumes.py
@@ -101,34 +101,37 @@ class VolumesTest(unittest.TestCase):
 
     @mock.patch.object(ResourceClient, 'delete')
     def test_delete_by_id_called_once(self, mock_delete):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+        id = 'fake'
+        uri = '/rest/storage-volumes/fake'
         self._volumes.delete(id, force=False, timeout=-1)
 
         expected_headers = {"If-Match": '*'}
-        mock_delete.assert_called_once_with(id, force=False, timeout=-1, custom_headers=expected_headers)
+        mock_delete.assert_called_once_with(uri, force=False, timeout=-1, custom_headers=expected_headers)
 
     @mock.patch.object(ResourceClient, 'delete')
     def test_delete_with_force_called_once(self, mock_delete):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
-        self._volumes.delete(id, force=True)
+        uri = '/rest/storage-volumes/fake'
+        self._volumes.delete(uri, force=True)
 
         mock_delete.assert_called_once_with(mock.ANY, force=True, timeout=mock.ANY, custom_headers=mock.ANY)
 
     @mock.patch.object(ResourceClient, 'delete')
     def test_delete_only_from_oneview_called_once_api300(self, mock_delete):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
-        self._volumes.delete(id, export_only=True)
+        uri = '/rest/storage-volumes/fake'
+        self._volumes.delete(uri, export_only=True)
 
         expected_headers = {'If-Match': '*', "exportOnly": True}
-        mock_delete.assert_called_once_with(id, force=mock.ANY, timeout=mock.ANY, custom_headers=expected_headers)
+        mock_delete.assert_called_once_with(uri, force=mock.ANY, timeout=mock.ANY, custom_headers=expected_headers)
 
     @mock.patch.object(ResourceClient, 'delete')
     def test_delete_only_from_oneview_called_once_api500(self, mock_delete):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
-        self._volumes.delete(id, suppress_device_updates=True)
+        uri = '/rest/storage-volumes/fake'
+        extended_uri = '/rest/storage-volumes/fake?suppressDeviceUpdates=true'
+        self._volumes.delete(uri, suppress_device_updates=True)
 
-        expected_headers = {'If-Match': '*', "suppressDeviceUpdates": True}
-        mock_delete.assert_called_once_with(id, force=mock.ANY, timeout=mock.ANY, custom_headers=expected_headers)
+        expected_headers = {'If-Match': '*'}
+        mock_delete.assert_called_once_with(extended_uri, force=mock.ANY,
+                                            timeout=mock.ANY, custom_headers=expected_headers)
 
     @mock.patch.object(ResourceClient, 'get_all')
     def test_get_snapshots_called_once(self, mock_get_all):


### PR DESCRIPTION
### Description
Fixes delete only method for in Storage Volumes API500.

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [x] Changes are documented in the CHANGELOG.
