### PR TITLE
Allow unassign of SH on SP by setting serverHardwareUri to None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Major release which extends support of the SDK to OneView Rest API version 500 (
 #### Breaking changes
 Legacy code under hpOneView which was marked as deprecated has been removed. This will cause scripts which still use legacy code to stop working. HPE recommends switching to the new modules which are officially supported.
 
+#### Bug fixes & Enhancements
+- [#300](https://github.com/HewlettPackard/python-hpOneView/issues/300) Unable to unassign Server Hardware from a Server Profile
+
 #### Features supported with current release:
 - Connection template
 - Datacenter

--- a/hpOneView/resources/servers/server_profiles.py
+++ b/hpOneView/resources/servers/server_profiles.py
@@ -76,6 +76,10 @@ class ServerProfiles(object):
         Returns:
             dict: The server profile resource.
         """
+        # Removes related fields to serverHardware in case of unassign
+        if resource.get('serverHardwareUri') is None:
+            resource.pop('enclosureBay', None)
+            resource.pop('enclosureUri', None)
         return self._client.update(resource=resource, uri=id_or_uri, default_values=self.DEFAULT_VALUES)
 
     def patch(self, id_or_uri, operation, path, value, timeout=-1):

--- a/tests/unit/resources/servers/test_server_profiles.py
+++ b/tests/unit/resources/servers/test_server_profiles.py
@@ -81,9 +81,10 @@ class ServerProfilesTest(TestCase):
     @mock.patch.object(ResourceClient, 'update')
     def test_update(self, mock_update):
         uri = "/rest/server-profiles/4ff2327f-7638-4b66-ad9d-283d4940a4ae"
-        template = dict(name="Server Profile Test", macType="Virtual")
+        template = dict(name="Server Profile Test", macType="Virtual",
+                        enclosureUri='/rest/fake', enclosureBay=3)
 
-        expected_template = template.copy()
+        expected_template = dict(name="Server Profile Test", macType="Virtual")
 
         self._resource.update(resource=template, id_or_uri=uri)
         mock_update.assert_called_once_with(resource=expected_template, uri=uri,


### PR DESCRIPTION
### Description
Fix to allow unassigning a SH by removing the serverHardwareUri key on a SP

1. Confirmed that setting serverHardwareUri to None or removing it and running update did not unassign the SH
2. Confirmed that unassign requires unsetting enclosureUri and enclosureBayUri
3. Added logic to remove enclosureUri and enclosureBayUri on update if serverHardwareUri is None

### Issues Resolved
#300 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [X] Changes are documented in the CHANGELOG.
