### PR TITLE
Catch http lib related exceptions as HpOneViewExceptions during login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v4.1.0 (Unreleased)
+# v4.1.0
 
 #### New Resources:
    - Appliance node information

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 #### New Resources:
    - Appliance node information
 
+#### Bug fixes & Enhancements
+- [#309](https://github.com/HewlettPackard/python-hpOneView/issues/309) HPOneViewException not raised when connection with paused VM fails
+
 # v4.0.0
 #### Notes
 Major release which extends support of the SDK to OneView Rest API version 500 (OneView v3.10).

--- a/hpOneView/connection.py
+++ b/hpOneView/connection.py
@@ -14,6 +14,7 @@ from __future__ import unicode_literals
 from builtins import open
 from builtins import str
 from future import standard_library
+from future.utils import raise_from
 
 standard_library.install_aliases()
 
@@ -483,7 +484,7 @@ class connection(object):
             if self._validateVersion is False:
                 self.validateVersion()
         except Exception as e:
-            raise HPOneViewException(str(e))
+            raise_from(HPOneViewException('Failure during login attempt.'), e)
 
         self._cred = cred
         try:

--- a/hpOneView/connection.py
+++ b/hpOneView/connection.py
@@ -479,8 +479,11 @@ class connection(object):
     # Login/Logout to/from appliance
     ###########################################################################
     def login(self, cred, verbose=False):
-        if self._validateVersion is False:
-            self.validateVersion()
+        try:
+            if self._validateVersion is False:
+                self.validateVersion()
+        except Exception as e:
+            raise HPOneViewException(str(e))
 
         self._cred = cred
         try:

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,10 @@ from setuptools import find_packages
 from setuptools import setup
 
 setup(name='hpOneView',
-      version='4.0.0',
+      version='4.1.0',
       description='HPE OneView Python Library',
       url='https://github.com/HewlettPackard/python-hpOneView',
-      download_url="https://github.com/HewlettPackard/python-hpOneView/tarball/v4.0.0",
+      download_url="https://github.com/HewlettPackard/python-hpOneView/tarball/v4.1.0",
       author='Hewlett Packard Enterprise Development LP',
       author_email='oneview-pythonsdk@hpe.com',
       license='MIT',

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -870,6 +870,13 @@ class ConnectionTest(unittest.TestCase):
         self.assertEqual(self.connection.get_session(), True)
 
     @patch.object(connection, 'get')
+    def test_login_catches_exceptions_as_hpOneView(self, mock_get):
+        mock_get.side_effect = [Exception('test')]
+
+        with self.assertRaises(HPOneViewException):
+            self.connection.login({})
+
+    @patch.object(connection, 'get')
     @patch.object(connection, 'post')
     def test_login_with_exception_in_post(self, mock_post, mock_get):
         mock_get.side_effect = [{'minimumVersion': 300, 'currentVersion': 400}]


### PR DESCRIPTION
### Description
Added try/except block to validateVersion in order to catch host unreachable and timeout exceptions during login attempts to appliance.

### Issues Resolved
Fixes #309 

### Check List
- [X] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [X] Changes are documented in the CHANGELOG.
