### PR TITLE
Fix pickle error with HPOneViewException

### DIFF
--- a/hpOneView/exceptions.py
+++ b/hpOneView/exceptions.py
@@ -84,6 +84,12 @@ class HPOneViewException(Exception):
         else:
             Exception.__init__(self, self.msg)
 
+    def __reduce__(self):
+        if self.oneview_response:
+            return (Exception, (self.msg, self.oneview_response))
+        else:
+            return (Exception, (self.msg,))
+
 
 class HPOneViewInvalidResource(HPOneViewException):
     """

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -24,6 +24,9 @@ import traceback
 import unittest
 import logging
 import mock
+import pickle
+import tempfile
+import os
 
 from hpOneView.exceptions import handle_exceptions
 from hpOneView.exceptions import HPOneViewException
@@ -118,6 +121,32 @@ class ExceptionsTest(unittest.TestCase):
         self.assertEqual(exception.msg, "The given data is empty!")
         self.assertEqual(exception.oneview_response, None)
         self.assertEqual(exception.args[0], "The given data is empty!")
+
+    def test_pickle_HPOneViewException_dict(self):
+        message = {"msg": "test message"}
+        exception = HPOneViewException(message)
+        tempf = tempfile.NamedTemporaryFile(delete=False)
+        with tempf as f:
+            pickle.dump(exception, f)
+
+        with open(tempf.name, 'rb') as f:
+            exception = pickle.load(f)
+
+        os.remove(tempf.name)
+        self.assertEqual('Exception', exception.__class__.__name__)
+
+    def test_pickle_HPOneViewException_message(self):
+        message = "test message"
+        exception = HPOneViewException(message)
+        tempf = tempfile.NamedTemporaryFile(delete=False)
+        with tempf as f:
+            pickle.dump(exception, f)
+
+        with open(tempf.name, 'rb') as f:
+            exception = pickle.load(f)
+
+        os.remove(tempf.name)
+        self.assertEqual('Exception', exception.__class__.__name__)
 
     @mock.patch.object(traceback, 'print_exception')
     @mock.patch.object(logging, 'error')


### PR DESCRIPTION
This commit fixes #320.

The problem seems to be that when oneview_response is not None the
Exception base class is called with two arguments whereas
HPOneViewException is defined to have one argument.  A simple fix is to
append self.oneview_response to self.msg and pass call Exception with
just self.msg

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve. e.g., Fixes #01]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
