### PR TITLE
Fix pickle problem with HPOneViewException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 #### Notes
 Added endpoints-support.md to track the supported and tested endpoints for the different HPE OneView REST APIs
 
+#### Bug fixes & Enhancements
+- [#320](https://github.com/HewlettPackard/python-hpOneView/issues/320) Issue with pickling HPOneViewException
+
 # v4.2.0
 #### New Resources:
 - Index resource

--- a/hpOneView/exceptions.py
+++ b/hpOneView/exceptions.py
@@ -67,7 +67,7 @@ class HPOneViewException(Exception):
        oneview_response (dict): OneView rest response.
    """
 
-    def __init__(self, data):
+    def __init__(self, data, error=None):
         self.msg = None
         self.oneview_response = None
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -24,6 +24,9 @@ import traceback
 import unittest
 import logging
 import mock
+import os
+import tempfile
+import pickle
 
 from hpOneView.exceptions import handle_exceptions
 from hpOneView.exceptions import HPOneViewException
@@ -118,6 +121,32 @@ class ExceptionsTest(unittest.TestCase):
         self.assertEqual(exception.msg, "The given data is empty!")
         self.assertEqual(exception.oneview_response, None)
         self.assertEqual(exception.args[0], "The given data is empty!")
+
+    def test_pickle_HPOneViewException_dict(self):
+        message = {"msg": "test message"}
+        exception = HPOneViewException(message)
+        tempf = tempfile.NamedTemporaryFile(delete=False)
+        with tempf as f:
+            pickle.dump(exception, f)
+
+        with open(tempf.name, 'rb') as f:
+            exception = pickle.load(f)
+
+        os.remove(tempf.name)
+        self.assertEqual('HPOneViewException', exception.__class__.__name__)
+
+    def test_pickle_HPOneViewException_message(self):
+        message = "test message"
+        exception = HPOneViewException(message)
+        tempf = tempfile.NamedTemporaryFile(delete=False)
+        with tempf as f:
+            pickle.dump(exception, f)
+
+        with open(tempf.name, 'rb') as f:
+            exception = pickle.load(f)
+
+        os.remove(tempf.name)
+        self.assertEqual('HPOneViewException', exception.__class__.__name__)
 
     @mock.patch.object(traceback, 'print_exception')
     @mock.patch.object(logging, 'error')


### PR DESCRIPTION
### Description
When self.oneview_response is not None Exception is called with two
arguments and as a result pickling of the class fails.  The simple fix
is to add another argument to the __init__ method, defaulting to None.
We've also added a couple of pickle unit tests.

### Issues Resolved
#320 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
- [ ] Changes are documented in the CHANGELOG.
