### PR TITLE
Removed a few unused/legacy methods from connections

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,4 +9,5 @@
   - [ ] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
 - [ ] New functionality has been documented in the README if applicable.
   - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
+  - [ ] New endpoints supported are updated in the endpoints-support.md file.
 - [ ] Changes are documented in the CHANGELOG.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Added endpoints-support.md to track the supported and tested endpoints for the d
 
 #### Bug fixes & Enhancements
 - [#320](https://github.com/HewlettPackard/python-hpOneView/issues/320) Issue with pickling HPOneViewException
+- [#330](https://github.com/HewlettPackard/python-hpOneView/issues/330) Remove unused/legacy code from connection.py
 
 # v4.2.0
 #### New Resources:

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -122,7 +122,7 @@
 |<sub>/rest/fcoe-networks/{id}</sub>                                                      | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/fcoe-networks/{id}</sub>                                                      | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Firmware Bundle**                                                                                                                          |
-|<sub>/rest/firmware-bundles/{id}/script</sub>                                            | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/firmware-bundles/</sub>                                                        | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Firmware Driver**                                                                                                                          |
 |<sub>/rest/firmware-drivers/</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/firmware-drivers/</sub>                                                       | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/hpOneView/connection.py
+++ b/hpOneView/connection.py
@@ -368,55 +368,6 @@ class connection(object):
     def patch(self, uri, body, custom_headers=None):
         return self.__do_rest_call('PATCH', uri, body, custom_headers=custom_headers)
 
-    def get_entities_byrange(self, uri, field, xmin, xmax, count=-1):
-        new_uri = uri + '?filter="\'' + field + '\'%20>%20\'' + xmin \
-                      + '\'"&filter="\'' + field + '\'%20<%20\'' + xmax \
-                      + '\'"&start=0&count=' + str(count)
-        body = self.get(new_uri)
-        return get_members(body)
-
-    def get_entities_byfield(self, uri, field, value, count=-1):
-        new_uri = uri + '?start=0&count=' + str(count) \
-                      + '&filter=' + field + '=\'' + value + '\''
-        try:
-            body = self.get(new_uri)
-        except:
-            print(new_uri)
-            raise
-        return get_members(body)
-
-    def get_entity_byfield(self, uri, field, value, count=-1):
-        new_uri = uri + '?filter="\'' + field + '\'%20=%20\'' + value \
-                      + '\'"&start=0&count=' + str(count)
-
-        try:
-            body = self.get(new_uri)
-        except:
-            print(new_uri)
-            raise
-        return get_member(body)
-
-    def conditional_post(self, uri, body):
-        try:
-            task, entity = self.post(uri, body)
-        except HPOneViewException as e:
-            # this may have failed because the entity already exists,
-            # unfortunately there is not a uniform way to report this,
-            # so we just try to find an existing entity with the same name
-            # and return it assuming all names are unique (which is a
-            # reasonable assumption)
-            if 'DUPLICATE' in e.errorCode and 'NAME' in e.errorCode:
-                try:
-                    entity = self.get_entity_byfield(uri, 'name', body['name'])
-                except Exception:
-                    # Didn't find the entity, raise exception
-                    raise e
-                if not entity:
-                    raise e
-            else:
-                raise e
-        return entity
-
     def __body_content_is_task(self, body):
         return isinstance(body, dict) and 'category' in body and body['category'] == 'tasks'
 


### PR DESCRIPTION
### Description

Removed a few unused/legacy methods from connections. 

This should also fix the flake8 tests which are failing on E722 due to those methods.

- Added newline to pull request template regarding tracking endpoints in
SDK
- Updated 2 lines in endpoints-support.md

### Issues Resolved
Fixes #330 

### Check List
- [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [x] Changes are documented in the CHANGELOG.
