### PR TITLE
Add connection timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
 - 2.7
+before_install:
+- pyenv global system 3.6
 install:
 - pip install tox
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.4.1 (Unreleased)
+#### Notes
+Added the capability to set a connection timeout when connecting to the HPE OneView Appliance
+
+
 # 4.4.0
 #### Notes
 Enabled usage of a CA Certificate file for establishing a SSL connection to the HPE OneView Appliance.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ export ONEVIEWSDK_API_VERSION='300'
 export ONEVIEWSDK_AUTH_LOGIN_DOMAIN='authdomain'
 export ONEVIEWSDK_SSL_CERTIFICATE='<path_to_cert.crt_file>'
 export ONEVIEWSDK_PROXY='<proxy_host>:<proxy_port>'
+export ONEVIEWSDK_CONNECTION_TIMEOUT='<connection time-out in seconds>'
 ```
 
 :lock: Tip: Make sure no unauthorized person has access to the environment variables, since the password is stored in clear-text.
@@ -243,6 +244,20 @@ build_plans = image_streamer_client.build_plans.get_all()
 ```
 
 You can find more usage examples in the folder ```/examples/image_streamer```
+
+### OneView Connection Timeout
+By default the system timeout is used when connecting to OneView.  If you want to change this,
+then the timeout can be set by either:
+
+1. Setting the appropriate environment variable:
+```bash
+export ONEVIEWSDK_CONNECTION_TIMEOUT='<connection time-out in seconds>'
+```
+
+2. Setting the time-out in the JSON configuration file using the following syntax:
+```json
+"timeout": <timeout in seconds>
+```
 
 ## Exception handling
 

--- a/hpOneView/oneview_client.py
+++ b/hpOneView/oneview_client.py
@@ -116,7 +116,8 @@ class OneViewClient(object):
     DEFAULT_API_VERSION = 300
 
     def __init__(self, config):
-        self.__connection = connection(config["ip"], config.get('api_version', self.DEFAULT_API_VERSION), config.get('ssl_certificate', False))
+        self.__connection = connection(config["ip"], config.get('api_version', self.DEFAULT_API_VERSION), config.get('ssl_certificate', False),
+                                       config.get('timeout'))
         self.__image_streamer_ip = config.get("image_streamer_ip")
         self.__set_proxy(config)
         self.__connection.login(config["credentials"])
@@ -216,8 +217,8 @@ class OneViewClient(object):
         Construct OneViewClient using environment variables.
 
         Allowed variables: ONEVIEWSDK_IP (required), ONEVIEWSDK_USERNAME (required), ONEVIEWSDK_PASSWORD (required),
-        ONEVIEWSDK_AUTH_LOGIN_DOMAIN, ONEVIEWSDK_API_VERSION, ONEVIEWSDK_IMAGE_STREAMER_IP, ONEVIEWSDK_SESSIONID, ONEVIEWSDK_SSL_CERTIFICATE
-        and ONEVIEWSDK_PROXY.
+        ONEVIEWSDK_AUTH_LOGIN_DOMAIN, ONEVIEWSDK_API_VERSION, ONEVIEWSDK_IMAGE_STREAMER_IP, ONEVIEWSDK_SESSIONID, ONEVIEWSDK_SSL_CERTIFICATE,
+        ONEVIEWSDK_CONNECTION_TIMEOUT and ONEVIEWSDK_PROXY.
 
         Returns:
             OneViewClient:
@@ -231,13 +232,14 @@ class OneViewClient(object):
         password = os.environ.get('ONEVIEWSDK_PASSWORD', '')
         proxy = os.environ.get('ONEVIEWSDK_PROXY', '')
         sessionID = os.environ.get('ONEVIEWSDK_SESSIONID', '')
+        timeout = os.environ.get('ONEVIEWSDK_CONNECTION_TIMEOUT')
 
         config = dict(ip=ip,
                       image_streamer_ip=image_streamer_ip,
                       api_version=api_version,
                       ssl_certificate=ssl_certificate,
                       credentials=dict(userName=username, authLoginDomain=auth_login_domain, password=password, sessionID=sessionID),
-                      proxy=proxy)
+                      proxy=proxy, timeout=timeout)
 
         return cls(config)
 

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -99,7 +99,8 @@ OS_ENVIRON_CONFIG_FULL = {
     'ONEVIEWSDK_PASSWORD': 'secret123',
     'ONEVIEWSDK_API_VERSION': '201',
     'ONEVIEWSDK_AUTH_LOGIN_DOMAIN': 'authdomain',
-    'ONEVIEWSDK_PROXY': '172.16.100.195:9999'
+    'ONEVIEWSDK_PROXY': '172.16.100.195:9999',
+    'ONEVIEWSDK_CONNECTION_TIMEOUT': '20'
 }
 
 OS_ENVIRON_CONFIG_FULL_WITH_SESSIONID = {
@@ -109,7 +110,9 @@ OS_ENVIRON_CONFIG_FULL_WITH_SESSIONID = {
     'ONEVIEWSDK_PASSWORD': 'secret123',
     'ONEVIEWSDK_SESSIONID': '123',
     'ONEVIEWSDK_API_VERSION': '201',
-    'ONEVIEWSDK_PROXY': '172.16.100.195:9999'
+    'ONEVIEWSDK_PROXY': '172.16.100.195:9999',
+    'ONEVIEWSDK_CONNECTION_TIMEOUT': '20'
+
 }
 
 
@@ -296,6 +299,7 @@ class OneViewClientTest(unittest.TestCase):
         OneViewClient.from_environment_variables()
         mock_cls.assert_called_once_with({'api_version': 201,
                                           'proxy': '172.16.100.195:9999',
+                                          'timeout': '20',
                                           'ip': '172.16.100.199',
                                           'ssl_certificate': '',
                                           'image_streamer_ip': '172.172.172.172',
@@ -312,6 +316,7 @@ class OneViewClientTest(unittest.TestCase):
         OneViewClient.from_environment_variables()
         mock_cls.assert_called_once_with({'api_version': 201,
                                           'proxy': '172.16.100.195:9999',
+                                          'timeout': '20',
                                           'ip': '172.16.100.199',
                                           'image_streamer_ip': '172.172.172.172',
                                           'ssl_certificate': '',
@@ -328,6 +333,7 @@ class OneViewClientTest(unittest.TestCase):
         OneViewClient.from_environment_variables()
         mock_cls.assert_called_once_with({'api_version': 300,
                                           'proxy': '',
+                                          'timeout': None,
                                           'ip': '172.16.100.199',
                                           'image_streamer_ip': '',
                                           'ssl_certificate': '',


### PR DESCRIPTION
We've had situations where we've hit against a system time-out when
connecting to OneView.  That timeout was over 2 minutes long.  To avoid
this we've added a timeout field to the config json, and if present the
value is used as a timeout in http.client.HTTPSConnection.

### Description
Adds a connection time-out

### Issues Resolved
[List any issues this PR will resolve. e.g., Fixes #01]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [ ] Changes are documented in the CHANGELOG.
