### PR TITLE
Api600 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # 4.4.1 (Unreleased)
 #### Notes
 Added the capability to set a connection timeout when connecting to the HPE OneView Appliance
+Major release which extends support of the SDK to OneView Rest API version 600 (OneView v4.0).
 
+#### Features supported with current release:
+- Connection Templates
+- FC Networks
+- Logical Interconnect Groups
+- Interconnect Types
+- SAS Logical Interconnect Groups
 
 # 4.4.0
 #### Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Extends support of the SDK to OneView Rest API version 600 (OneView v4.0).
 #### Features supported with current release:
 - Connection template
 - FC network
-- Logical interconnect group
 - Interconnect type
+- Logical interconnect group
 - SAS logical interconnect group
 
 # 4.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
-# 5.0.0 (Unreleased)
+# 4.5.0 (Unreleased)
 #### Notes
 Added the capability to set a connection timeout when connecting to the HPE OneView Appliance
-Major release which extends support of the SDK to OneView Rest API version 600 (OneView v4.0).
+Extends support of the SDK to OneView Rest API version 600 (OneView v4.0).
 
 #### Features supported with current release:
-- Connection Templates
-- FC Networks
-- Logical Interconnect Groups
-- Interconnect Types
-- SAS Logical Interconnect Groups
+- Connection template
+- FC network
+- Logical interconnect group
+- Interconnect type
+- SAS logical interconnect group
 
 # 4.4.0
 #### Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 4.4.1 (Unreleased)
+# 5.0.0 (Unreleased)
 #### Notes
 Added the capability to set a connection timeout when connecting to the HPE OneView Appliance
 Major release which extends support of the SDK to OneView Rest API version 600 (OneView v4.0).

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -116,7 +116,7 @@
 |<sub>/rest/fc-networks</sub>                                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/fc-networks</sub>                                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/fc-networks/{id}</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fc-networks/{id}</sub>                                                        | PATCH    | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |  :heavy_minus_sign:  |
+|<sub>/rest/fc-networks/{id}</sub>                                                        | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |  :heavy_minus_sign:  |
 |<sub>/rest/fc-networks/{id}</sub>                                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/fc-networks/{id}</sub>                                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **FCoE Networks**                                                                                                                             |

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -18,8 +18,8 @@
 
 ## HPE OneView
 
-| Endpoints                                                                       | Verb     | V200 | V300 | V500 |
-| --------------------------------------------------------------------------------------- | -------- | :------------------: | :------------------: | :------------------: |
+| Endpoints                                                                       | Verb     | V200 | V300 | V500 |V600
+| --------------------------------------------------------------------------------------- | -------- | :------------------: | :------------------: | :------------------: | :------------------: |
 |     **Alerts**                                                                                                                                   |
 |<sub>/rest/alerts	</sub>                                                                |GET       | :white_check_mark:    | :white_check_mark:   |
 |<sub>/rest/alerts	</sub>                                                                |DELETE    | :white_check_mark:   | :white_check_mark:   |
@@ -51,10 +51,10 @@
 |<sub>/rest/certificates/client/rabbitmq/keys/{aliasName}</sub>                           |GET       | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/certificates/client/rabbitmq/{aliasName}</sub>                                |GET       | :white_check_mark:   | :white_check_mark:   |
 |     **Connection Templates**                                                                                                                      |
-|<sub>/rest/connection-templates</sub>                                                    |GET       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/connection-templates/defaultConnectionTemplate</sub>                          |GET       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/connection-templates/{id}</sub>                                               |GET       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/connection-templates/{id}</sub>                                               |PUT       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/connection-templates</sub>                                                    |GET       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/connection-templates/defaultConnectionTemplate</sub>                          |GET       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/connection-templates/{id}</sub>                                               |GET       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/connection-templates/{id}</sub>                                               |PUT       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Datacenters**                                                                                                                               |
 |<sub>/rest/datacenters</sub>                                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/datacenters</sub>                                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
@@ -113,12 +113,12 @@
 |<sub>/rest/fabrics/{id}/reserved-vlan-range</sub>                                        | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/fabrics/{id}/reserved-vlan-range</sub>                                        | PUT      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
 |     **FC Networks**                                                                                                                               |
-|<sub>/rest/fc-networks</sub>                                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fc-networks</sub>                                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fc-networks/{id}</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fc-networks/{id}</sub>                                                        | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark: |
-|<sub>/rest/fc-networks/{id}</sub>                                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fc-networks/{id}</sub>                                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-networks</sub>                                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-networks</sub>                                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-networks/{id}</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-networks/{id}</sub>                                                        | PATCH    | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |  :heavy_minus_sign:  |
+|<sub>/rest/fc-networks/{id}</sub>                                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-networks/{id}</sub>                                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **FCoE Networks**                                                                                                                             |
 |<sub>/rest/fcoe-networks</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/fcoe-networks</sub>                                                           | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
@@ -186,8 +186,8 @@
 |<sub>/rest/interconnect-link-topologies</sub>                                            | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/interconnect-link-topologies/{id}</sub>                                        | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
 |     **Interconnect Types**                                                                                                                        |
-|<sub>/rest/interconnect-types</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnect-types/{id}</sub>                                                 | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnect-types</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnect-types/{id}</sub>                                                 | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Interconnects**                                                                                                                            |
 |<sub>/rest/interconnects</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/interconnects/{id}</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
@@ -236,14 +236,14 @@
 |<sub>/rest/logical-enclosures/{id}/support-dumps</sub>                                   | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/logical-enclosures/{id}/updateFromGroup</sub>                                 | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Logical Interconnect Groups**                                                                                                               |
-|<sub>/rest/logical-interconnect-groups</sub>                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups</sub>                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/defaultSettings</sub>                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | PATCH    | :heavy_minus_sign: | :white_check_mark: | :white_check_mark: |
-|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/{id}/settings</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups</sub>                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups</sub>                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/defaultSettings</sub>                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | PATCH    | :heavy_minus_sign: | :white_check_mark: | :white_check_mark: | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/{id}/settings</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Logical Interconnects**                                                                                                                     |
 |<sub>/rest/logical-interconnects</sub>                                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/logical-interconnects/locations/interconnects</sub>                           | POST     | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
@@ -380,11 +380,11 @@
 |<sub>/rest/sas-interconnects/{id}</sub>                                                  | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/sas-interconnects/{id}/refreshState</sub>                                     | PUT      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
 |     **SAS Logical Interconnect Groups**                                                                                                          |
-|<sub>/rest/sas-logical-interconnect-groups</sub>                                         | POST     | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-logical-interconnect-groups</sub>                                         | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-logical-interconnect-groups/{id}</sub>                                    | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-logical-interconnect-groups/{id}</sub>                                    | PUT      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-logical-interconnect-groups/{id}</sub>                                    | DELETE   | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnect-groups</sub>                                         | POST     | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnect-groups</sub>                                         | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnect-groups/{id}</sub>                                    | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnect-groups/{id}</sub>                                    | PUT      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnect-groups/{id}</sub>                                    | DELETE   | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **SAS Logical Interconnects**                                                                                                                |
 |<sub>/rest/sas-logical-interconnects</sub>                                               | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/sas-logical-interconnects/{id}</sub>                                          | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |

--- a/hpOneView/resources/networking/fc_networks.py
+++ b/hpOneView/resources/networking/fc_networks.py
@@ -44,7 +44,8 @@ class FcNetworks(object):
     DEFAULT_VALUES = {
         '200': {'type': 'fc-networkV2'},
         '300': {"type": "fc-networkV300"},
-        '500': {"type": "fc-networkV300"}
+        '500': {"type": "fc-networkV300"},
+	'600': {"type": "fc-networkV4"}
     }
 
     def __init__(self, con):

--- a/hpOneView/resources/networking/fc_networks.py
+++ b/hpOneView/resources/networking/fc_networks.py
@@ -45,7 +45,7 @@ class FcNetworks(object):
         '200': {'type': 'fc-networkV2'},
         '300': {"type": "fc-networkV300"},
         '500': {"type": "fc-networkV300"},
-	'600': {"type": "fc-networkV4"}
+        '600': {"type": "fc-networkV4"}
     }
 
     def __init__(self, con):

--- a/hpOneView/resources/networking/logical_interconnect_groups.py
+++ b/hpOneView/resources/networking/logical_interconnect_groups.py
@@ -44,14 +44,15 @@ class LogicalInterconnectGroups(object):
     DEFAULT_VALUES = {
         '200': {"type": "logical-interconnect-groupV3"},
         '300': {"type": "logical-interconnect-groupV300"},
-        '500': {"type": "logical-interconnect-groupV300"}
+        '500': {"type": "logical-interconnect-groupV300"},
+ 	'600': {"type": "logical-interconnect-groupV4"}
     }
 
     def __init__(self, con):
         self._connection = con
         self._client = ResourceClient(con, self.URI)
 
-    def get_all(self, start=0, count=-1, filter='', sort=''):
+    def get_all(self, start=0, count=-1, filter='', sort='',scopeUris=''):
         """
         Gets a list of logical interconnect groups based on optional sorting and filtering and is constrained by start
         and count parameters.
@@ -74,7 +75,7 @@ class LogicalInterconnectGroups(object):
         Returns:
             list: A list of logical interconnect groups.
         """
-        return self._client.get_all(start, count, filter=filter, sort=sort)
+        return self._client.get_all(start, count, filter=filter, sort=sort,scopeUris=scopeUris)
 
     def get(self, id_or_uri):
         """

--- a/hpOneView/resources/networking/logical_interconnect_groups.py
+++ b/hpOneView/resources/networking/logical_interconnect_groups.py
@@ -52,7 +52,7 @@ class LogicalInterconnectGroups(object):
         self._connection = con
         self._client = ResourceClient(con, self.URI)
 
-    def get_all(self, start=0, count=-1, filter='', sort='', scopeUris=''):
+    def get_all(self, start=0, count=-1, filter='', sort='', scope_uris=''):
         """
         Gets a list of logical interconnect groups based on optional sorting and filtering and is constrained by start
         and count parameters.
@@ -71,14 +71,14 @@ class LogicalInterconnectGroups(object):
             sort:
                 The sort order of the returned data set. By default, the sort order is based
                 on create time with the oldest entry first.
-            scopeUris:
+            scope_uris:
                 An expression to restrict the resources returned according to the scopes to
                 which they are assigned.
 
         Returns:
             list: A list of logical interconnect groups.
         """
-        return self._client.get_all(start, count, filter=filter, sort=sort, scopeUris=scopeUris)
+        return self._client.get_all(start, count, filter=filter, sort=sort, scope_uris=scope_uris)
 
     def get(self, id_or_uri):
         """

--- a/hpOneView/resources/networking/logical_interconnect_groups.py
+++ b/hpOneView/resources/networking/logical_interconnect_groups.py
@@ -45,14 +45,14 @@ class LogicalInterconnectGroups(object):
         '200': {"type": "logical-interconnect-groupV3"},
         '300': {"type": "logical-interconnect-groupV300"},
         '500': {"type": "logical-interconnect-groupV300"},
- 	'600': {"type": "logical-interconnect-groupV4"}
+        '600': {"type": "logical-interconnect-groupV4"}
     }
 
     def __init__(self, con):
         self._connection = con
         self._client = ResourceClient(con, self.URI)
 
-    def get_all(self, start=0, count=-1, filter='', sort='',scopeUris=''):
+    def get_all(self, start=0, count=-1, filter='', sort='', scopeUris=''):
         """
         Gets a list of logical interconnect groups based on optional sorting and filtering and is constrained by start
         and count parameters.
@@ -75,7 +75,7 @@ class LogicalInterconnectGroups(object):
         Returns:
             list: A list of logical interconnect groups.
         """
-        return self._client.get_all(start, count, filter=filter, sort=sort,scopeUris=scopeUris)
+        return self._client.get_all(start, count, filter=filter, sort=sort, scopeUris=scopeUris)
 
     def get(self, id_or_uri):
         """

--- a/hpOneView/resources/networking/logical_interconnect_groups.py
+++ b/hpOneView/resources/networking/logical_interconnect_groups.py
@@ -71,6 +71,9 @@ class LogicalInterconnectGroups(object):
             sort:
                 The sort order of the returned data set. By default, the sort order is based
                 on create time with the oldest entry first.
+            scopeUris:
+                An expression to restrict the resources returned according to the scopes to
+                which they are assigned.
 
         Returns:
             list: A list of logical interconnect groups.

--- a/hpOneView/resources/networking/sas_logical_interconnect_groups.py
+++ b/hpOneView/resources/networking/sas_logical_interconnect_groups.py
@@ -46,13 +46,13 @@ class SasLogicalInterconnectGroups(object):
     DEFAULT_VALUES = {
         '300': {'type': 'sas-logical-interconnect-group'},
         '500': {'type': 'sas-logical-interconnect-group'},
-	'600': {'type': 'sas-logical-interconnect-groupV2'},
+        '600': {'type': 'sas-logical-interconnect-groupV2'},
     }
 
     def __init__(self, con):
         self._client = ResourceClient(con, self.URI)
 
-    def get_all(self, start=0, count=-1, filter='', sort='', scopeUris='', view='', fields=''):
+    def get_all(self, start=0, count=-1, filter='', sort='', scopeUris=''):
         """
         Gets a paginated collection of SAS logical interconnect groups. The collection is based
         on optional sorting and filtering and is constrained by start and count parameters.
@@ -75,7 +75,7 @@ class SasLogicalInterconnectGroups(object):
         Returns:
             list: A list of SAS logical interconnect groups.
         """
-        return self._client.get_all(start, count, filter=filter, sort=sort, scopeUris=scopeUris, view=view, fields=fields)
+        return self._client.get_all(start, count, filter=filter, sort=sort, scopeUris=scopeUris)
 
     def get(self, id_or_uri):
         """

--- a/hpOneView/resources/networking/sas_logical_interconnect_groups.py
+++ b/hpOneView/resources/networking/sas_logical_interconnect_groups.py
@@ -71,6 +71,10 @@ class SasLogicalInterconnectGroups(object):
             sort:
                 The sort order of the returned data set. By default, the sort order is based
                 on create time with the oldest entry first.
+            scopeUris:
+                An expression to restrict the resources returned according to the scopes to
+                which they are assigned.
+
 
         Returns:
             list: A list of SAS logical interconnect groups.

--- a/hpOneView/resources/networking/sas_logical_interconnect_groups.py
+++ b/hpOneView/resources/networking/sas_logical_interconnect_groups.py
@@ -52,7 +52,7 @@ class SasLogicalInterconnectGroups(object):
     def __init__(self, con):
         self._client = ResourceClient(con, self.URI)
 
-    def get_all(self, start=0, count=-1, filter='', sort='', scopeUris=''):
+    def get_all(self, start=0, count=-1, filter='', sort='', scope_uris=''):
         """
         Gets a paginated collection of SAS logical interconnect groups. The collection is based
         on optional sorting and filtering and is constrained by start and count parameters.
@@ -71,7 +71,7 @@ class SasLogicalInterconnectGroups(object):
             sort:
                 The sort order of the returned data set. By default, the sort order is based
                 on create time with the oldest entry first.
-            scopeUris:
+            scope_uris:
                 An expression to restrict the resources returned according to the scopes to
                 which they are assigned.
 
@@ -79,7 +79,7 @@ class SasLogicalInterconnectGroups(object):
         Returns:
             list: A list of SAS logical interconnect groups.
         """
-        return self._client.get_all(start, count, filter=filter, sort=sort, scopeUris=scopeUris)
+        return self._client.get_all(start, count, filter=filter, sort=sort, scope_uris=scope_uris)
 
     def get(self, id_or_uri):
         """

--- a/hpOneView/resources/networking/sas_logical_interconnect_groups.py
+++ b/hpOneView/resources/networking/sas_logical_interconnect_groups.py
@@ -45,13 +45,14 @@ class SasLogicalInterconnectGroups(object):
 
     DEFAULT_VALUES = {
         '300': {'type': 'sas-logical-interconnect-group'},
-        '500': {'type': 'sas-logical-interconnect-group'}
+        '500': {'type': 'sas-logical-interconnect-group'},
+	'600': {'type': 'sas-logical-interconnect-groupV2'},
     }
 
     def __init__(self, con):
         self._client = ResourceClient(con, self.URI)
 
-    def get_all(self, start=0, count=-1, filter='', sort=''):
+    def get_all(self, start=0, count=-1, filter='', sort='', scopeUris='', view='', fields=''):
         """
         Gets a paginated collection of SAS logical interconnect groups. The collection is based
         on optional sorting and filtering and is constrained by start and count parameters.
@@ -74,7 +75,7 @@ class SasLogicalInterconnectGroups(object):
         Returns:
             list: A list of SAS logical interconnect groups.
         """
-        return self._client.get_all(start, count, filter=filter, sort=sort)
+        return self._client.get_all(start, count, filter=filter, sort=sort, scopeUris=scopeUris, view=view, fields=fields)
 
     def get(self, id_or_uri):
         """

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -96,7 +96,7 @@ class ResourceClient(object):
         self._uri = uri
         self._task_monitor = TaskMonitor(con)
 
-    def build_query_uri(self, start=0, count=-1, filter='', query='', sort='', view='', fields='', scope_uris='', uri=None):
+    def build_query_uri(self, start=0, count=-1, filter='', query='', sort='', view='', fields='', uri=None, scope_uris=''):
         """
         Builds the URI given the parameters.
 
@@ -171,7 +171,7 @@ class ResourceClient(object):
 
         return uri
 
-    def get_all(self, start=0, count=-1, filter='', query='', sort='', view='', fields='', scope_uris='', uri=None):
+    def get_all(self, start=0, count=-1, filter='', query='', sort='', view='', fields='', uri=None, scope_uris=''):
         """
         Gets all items according with the given arguments.
 
@@ -207,7 +207,7 @@ class ResourceClient(object):
         """
 
         uri = self.build_query_uri(start=start, count=count, filter=filter,
-                                   query=query, sort=sort, view=view, fields=fields, scope_uris=scope_uris, uri=uri)
+                                   query=query, sort=sort, view=view, fields=fields, uri=uri, scope_uris=scope_uris)
 
         logger.debug('Getting all resources with uri: {0}'.format(uri))
 

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -48,13 +48,7 @@ RESOURCE_CLIENT_TASK_EXPECTED = "Failed: Expected a TaskResponse."
 RESOURCE_ID_OR_URI_REQUIRED = 'It is required to inform the Resource ID or URI.'
 
 
-logger = logging.getLogger('hpOneView')
-
-handler = logging.StreamHandler()
-formatter = logging.Formatter('%(asctime)s %(levelname)-8s %(name)-12s %(message)s')
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-logger.setLevel(logging.DEBUG)
+logger = logging.getLogger('__name__')
 
 def merge_resources(resource1, resource2):
     """

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -48,7 +48,7 @@ RESOURCE_CLIENT_TASK_EXPECTED = "Failed: Expected a TaskResponse."
 RESOURCE_ID_OR_URI_REQUIRED = 'It is required to inform the Resource ID or URI.'
 
 
-logger = logging.getLogger('__name__')
+logger = logging.getLogger(__name__)
 
 
 def merge_resources(resource1, resource2):
@@ -135,6 +135,9 @@ class ResourceClient(object):
                 Name of the fields.
             uri:
                 A specific URI (optional)
+            scopeUris:
+                An expression to restrict the resources returned according to the scopes to
+                which they are assigned.
 
         Returns:
             uri: The complete uri
@@ -168,7 +171,7 @@ class ResourceClient(object):
 
         return uri
 
-    def get_all(self, start=0, count=-1, filter='', query='', sort='', view='', fields='', uri=None, scopeUris=''):
+    def get_all(self, start=0, count=-1, filter='', query='', sort='', view='', fields='', scopeUris='', uri=None):
         """
         Gets all items according with the given arguments.
 
@@ -204,7 +207,7 @@ class ResourceClient(object):
         """
 
         uri = self.build_query_uri(start=start, count=count, filter=filter,
-                                   query=query, sort=sort, view=view, fields=fields, uri=uri, scopeUris=scopeUris)
+                                   query=query, sort=sort, view=view, fields=fields, scopeUris=scopeUris, uri=uri)
 
         logger.debug('Getting all resources with uri: {0}'.format(uri))
 

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -48,8 +48,13 @@ RESOURCE_CLIENT_TASK_EXPECTED = "Failed: Expected a TaskResponse."
 RESOURCE_ID_OR_URI_REQUIRED = 'It is required to inform the Resource ID or URI.'
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('hpOneView')
 
+handler = logging.StreamHandler()
+formatter = logging.Formatter('%(asctime)s %(levelname)-8s %(name)-12s %(message)s')
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)
 
 def merge_resources(resource1, resource2):
     """
@@ -96,7 +101,7 @@ class ResourceClient(object):
         self._uri = uri
         self._task_monitor = TaskMonitor(con)
 
-    def build_query_uri(self, start=0, count=-1, filter='', query='', sort='', view='', fields='', uri=None):
+    def build_query_uri(self, start=0, count=-1, filter='', query='', sort='', view='', fields='', scopeUris='', uri=None):
         """
         Builds the URI given the parameters.
 
@@ -155,17 +160,20 @@ class ResourceClient(object):
         if fields:
             fields = "&fields=" + quote(fields)
 
+	if scopeUris:
+	    scopeUris = "&scopeUris=" + quote(scopeUris)
+
         path = uri if uri else self._uri
         self.__validate_resource_uri(path)
 
         symbol = '?' if '?' not in path else '&'
 
-        uri = "{0}{1}start={2}&count={3}{4}{5}{6}{7}{8}".format(path, symbol, start, count, filter, query, sort,
-                                                                view, fields)
+        uri = "{0}{1}start={2}&count={3}{4}{5}{6}{7}{8}{9}".format(path, symbol, start, count, filter, query, sort,
+                                                                view, fields, scopeUris)
 
         return uri
 
-    def get_all(self, start=0, count=-1, filter='', query='', sort='', view='', fields='', uri=None):
+    def get_all(self, start=0, count=-1, filter='', query='', sort='', view='', fields='', uri=None, scopeUris=''):
         """
         Gets all items according with the given arguments.
 
@@ -192,13 +200,15 @@ class ResourceClient(object):
                 Name of the fields.
             uri:
                 A specific URI (optional)
+	    scopeUris:
+
 
         Returns:
             list: A list of items matching the specified filter.
         """
 
         uri = self.build_query_uri(start=start, count=count, filter=filter,
-                                   query=query, sort=sort, view=view, fields=fields, uri=uri)
+                                   query=query, sort=sort, view=view, fields=fields, uri=uri,scopeUris=scopeUris)
 
         logger.debug('Getting all resources with uri: {0}'.format(uri))
 

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -96,7 +96,7 @@ class ResourceClient(object):
         self._uri = uri
         self._task_monitor = TaskMonitor(con)
 
-    def build_query_uri(self, start=0, count=-1, filter='', query='', sort='', view='', fields='', scopeUris='', uri=None):
+    def build_query_uri(self, start=0, count=-1, filter='', query='', sort='', view='', fields='', scope_uris='', uri=None):
         """
         Builds the URI given the parameters.
 
@@ -135,7 +135,7 @@ class ResourceClient(object):
                 Name of the fields.
             uri:
                 A specific URI (optional)
-            scopeUris:
+            scope_uris:
                 An expression to restrict the resources returned according to the scopes to
                 which they are assigned.
 
@@ -158,8 +158,8 @@ class ResourceClient(object):
         if fields:
             fields = "&fields=" + quote(fields)
 
-        if scopeUris:
-            scopeUris = "&scopeUris=" + quote(scopeUris)
+        if scope_uris:
+            scope_uris = "&scope_uris=" + quote(scope_uris)
 
         path = uri if uri else self._uri
         self.__validate_resource_uri(path)
@@ -167,11 +167,11 @@ class ResourceClient(object):
         symbol = '?' if '?' not in path else '&'
 
         uri = "{0}{1}start={2}&count={3}{4}{5}{6}{7}{8}{9}".format(path, symbol, start, count, filter, query, sort,
-                                                                   view, fields, scopeUris)
+                                                                   view, fields, scope_uris)
 
         return uri
 
-    def get_all(self, start=0, count=-1, filter='', query='', sort='', view='', fields='', scopeUris='', uri=None):
+    def get_all(self, start=0, count=-1, filter='', query='', sort='', view='', fields='', scope_uris='', uri=None):
         """
         Gets all items according with the given arguments.
 
@@ -198,7 +198,7 @@ class ResourceClient(object):
                 Name of the fields.
             uri:
                 A specific URI (optional)
-            scopeUris:
+            scope_uris:
                 An expression to restrict the resources returned according to the scopes to
                 which they are assigned.
 
@@ -207,7 +207,7 @@ class ResourceClient(object):
         """
 
         uri = self.build_query_uri(start=start, count=count, filter=filter,
-                                   query=query, sort=sort, view=view, fields=fields, scopeUris=scopeUris, uri=uri)
+                                   query=query, sort=sort, view=view, fields=fields, scope_uris=scope_uris, uri=uri)
 
         logger.debug('Getting all resources with uri: {0}'.format(uri))
 

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -50,6 +50,7 @@ RESOURCE_ID_OR_URI_REQUIRED = 'It is required to inform the Resource ID or URI.'
 
 logger = logging.getLogger('__name__')
 
+
 def merge_resources(resource1, resource2):
     """
     Updates a copy of resource1 with resource2 values and returns the merged dictionary.
@@ -154,8 +155,8 @@ class ResourceClient(object):
         if fields:
             fields = "&fields=" + quote(fields)
 
-	if scopeUris:
-	    scopeUris = "&scopeUris=" + quote(scopeUris)
+        if scopeUris:
+            scopeUris = "&scopeUris=" + quote(scopeUris)
 
         path = uri if uri else self._uri
         self.__validate_resource_uri(path)
@@ -163,7 +164,7 @@ class ResourceClient(object):
         symbol = '?' if '?' not in path else '&'
 
         uri = "{0}{1}start={2}&count={3}{4}{5}{6}{7}{8}{9}".format(path, symbol, start, count, filter, query, sort,
-                                                                view, fields, scopeUris)
+                                                                   view, fields, scopeUris)
 
         return uri
 
@@ -194,7 +195,7 @@ class ResourceClient(object):
                 Name of the fields.
             uri:
                 A specific URI (optional)
-	    scopeUris:
+            scopeUris:
 
 
         Returns:
@@ -202,7 +203,7 @@ class ResourceClient(object):
         """
 
         uri = self.build_query_uri(start=start, count=count, filter=filter,
-                                   query=query, sort=sort, view=view, fields=fields, uri=uri,scopeUris=scopeUris)
+                                   query=query, sort=sort, view=view, fields=fields, uri=uri, scopeUris=scopeUris)
 
         logger.debug('Getting all resources with uri: {0}'.format(uri))
 

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -196,7 +196,8 @@ class ResourceClient(object):
             uri:
                 A specific URI (optional)
             scopeUris:
-
+                An expression to restrict the resources returned according to the scopes to
+                which they are assigned.
 
         Returns:
             list: A list of items matching the specified filter.

--- a/tests/unit/resources/networking/test_logical_interconnect_groups.py
+++ b/tests/unit/resources/networking/test_logical_interconnect_groups.py
@@ -40,16 +40,16 @@ class LogicalInterconnectGroupsTest(unittest.TestCase):
     def test_get_all_called_once(self, mock_get_all):
         filter = 'name=TestName'
         sort = 'name:ascending'
-        scopeUris = 'TestScope'
+        scope_uris = 'TestScope'
 
-        self._lig.get_all(2, 500, filter, sort, scopeUris)
+        self._lig.get_all(2, 500, filter, sort, scope_uris)
 
-        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort, scopeUris=scopeUris)
+        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort, scope_uris=scope_uris)
 
     @mock.patch.object(ResourceClient, 'get_all')
     def test_get_all_called_once_with_default(self, mock_get_all):
         self._lig.get_all()
-        mock_get_all.assert_called_once_with(0, -1, filter='', sort='', scopeUris='')
+        mock_get_all.assert_called_once_with(0, -1, filter='', sort='', scope_uris='')
 
     @mock.patch.object(ResourceClient, 'get')
     def test_get_by_id_called_once(self, mock_get):

--- a/tests/unit/resources/networking/test_logical_interconnect_groups.py
+++ b/tests/unit/resources/networking/test_logical_interconnect_groups.py
@@ -40,15 +40,16 @@ class LogicalInterconnectGroupsTest(unittest.TestCase):
     def test_get_all_called_once(self, mock_get_all):
         filter = 'name=TestName'
         sort = 'name:ascending'
+        scopeUris = 'TestScope'
 
-        self._lig.get_all(2, 500, filter, sort)
+        self._lig.get_all(2, 500, filter, sort, scopeUris)
 
-        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort)
+        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort, scopeUris=scopeUris)
 
     @mock.patch.object(ResourceClient, 'get_all')
     def test_get_all_called_once_with_default(self, mock_get_all):
         self._lig.get_all()
-        mock_get_all.assert_called_once_with(0, -1, filter='', sort='')
+        mock_get_all.assert_called_once_with(0, -1, filter='', sort='', scopeUris='')
 
     @mock.patch.object(ResourceClient, 'get')
     def test_get_by_id_called_once(self, mock_get):

--- a/tests/unit/resources/networking/test_sas_logical_interconnect_groups.py
+++ b/tests/unit/resources/networking/test_sas_logical_interconnect_groups.py
@@ -40,11 +40,11 @@ class SasLogicalInterconnectGroupsTest(unittest.TestCase):
     def test_get_all_called_once(self, mock_get_all):
         filter = 'name=TestName'
         sort = 'name:ascending'
-        scopeUris = 'TestScope'
+        scope_uris = 'TestScope'
 
-        self._resource.get_all(2, 500, filter, sort, scopeUris)
+        self._resource.get_all(2, 500, filter, sort, scope_uris)
 
-        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort, scopeUris=scopeUris)
+        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort, scope_uris=scope_uris)
 
     @mock.patch.object(ResourceClient, 'get')
     def test_get_by_id_called_once(self, mock_get):

--- a/tests/unit/resources/networking/test_sas_logical_interconnect_groups.py
+++ b/tests/unit/resources/networking/test_sas_logical_interconnect_groups.py
@@ -40,10 +40,11 @@ class SasLogicalInterconnectGroupsTest(unittest.TestCase):
     def test_get_all_called_once(self, mock_get_all):
         filter = 'name=TestName'
         sort = 'name:ascending'
+        scopeUris = 'TestScope'
 
-        self._resource.get_all(2, 500, filter, sort)
+        self._resource.get_all(2, 500, filter, sort, scopeUris)
 
-        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort)
+        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort, scopeUris=scopeUris)
 
     @mock.patch.object(ResourceClient, 'get')
     def test_get_by_id_called_once(self, mock_get):

--- a/tests/unit/resources/test_resource.py
+++ b/tests/unit/resources/test_resource.py
@@ -94,11 +94,12 @@ class ResourceClientTest(unittest.TestCase):
         sort = 'name:ascending'
         query = "name NE 'WrongName'"
         view = '"{view-name}"'
+        scopeUris = '/rest/scopes/test'
 
         mock_get.return_value = {"members": [{"member": "member"}]}
 
         result = self.resource_client.get_all(
-            1, 500, filter, query, sort, view, 'name,owner,modified')
+            1, 500, filter, query, sort, view, 'name,owner,modified', scopeUris)
 
         uri = '{resource_uri}?start=1' \
               '&count=500' \
@@ -106,7 +107,8 @@ class ResourceClientTest(unittest.TestCase):
               '&query=name%20NE%20%27WrongName%27' \
               '&sort=name%3Aascending' \
               '&view=%22%7Bview-name%7D%22' \
-              '&fields=name%2Cowner%2Cmodified'.format(resource_uri=self.URI)
+              '&fields=name%2Cowner%2Cmodified' \
+              '&scopeUris=/rest/scopes/test'.format(resource_uri=self.URI)
 
         self.assertEqual([{'member': 'member'}], result)
         mock_get.assert_called_once_with(uri)

--- a/tests/unit/resources/test_resource.py
+++ b/tests/unit/resources/test_resource.py
@@ -99,7 +99,7 @@ class ResourceClientTest(unittest.TestCase):
         mock_get.return_value = {"members": [{"member": "member"}]}
 
         result = self.resource_client.get_all(
-            1, 500, filter, query, sort, view, 'name,owner,modified', scope_uris)
+            1, 500, filter, query, sort, view, 'name,owner,modified', scope_uris=scope_uris)
 
         uri = '{resource_uri}?start=1' \
               '&count=500' \

--- a/tests/unit/resources/test_resource.py
+++ b/tests/unit/resources/test_resource.py
@@ -94,12 +94,12 @@ class ResourceClientTest(unittest.TestCase):
         sort = 'name:ascending'
         query = "name NE 'WrongName'"
         view = '"{view-name}"'
-        scopeUris = '/rest/scopes/test'
+        scope_uris = '/rest/scopes/cd237b60-09e2-45c4-829e-082e318a6d2a'
 
         mock_get.return_value = {"members": [{"member": "member"}]}
 
         result = self.resource_client.get_all(
-            1, 500, filter, query, sort, view, 'name,owner,modified', scopeUris)
+            1, 500, filter, query, sort, view, 'name,owner,modified', scope_uris)
 
         uri = '{resource_uri}?start=1' \
               '&count=500' \
@@ -108,7 +108,7 @@ class ResourceClientTest(unittest.TestCase):
               '&sort=name%3Aascending' \
               '&view=%22%7Bview-name%7D%22' \
               '&fields=name%2Cowner%2Cmodified' \
-              '&scopeUris=/rest/scopes/test'.format(resource_uri=self.URI)
+              '&scope_uris=/rest/scopes/cd237b60-09e2-45c4-829e-082e318a6d2a'.format(resource_uri=self.URI)
 
         self.assertEqual([{'member': 'member'}], result)
         mock_get.assert_called_once_with(uri)


### PR DESCRIPTION
### Description
Extending SDK support for REST Api600 for following resources:
- Connection Templates
- FC Networks
- Logical Interconnect Groups
- Interconnect Types
- SAS Logical Interconnect Groups

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [X] New endpoints supported are updated in the endpoints-support.md file.
- [X] Changes are documented in the CHANGELOG.
