### PR TITLE
Api600 resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,21 @@
 # 4.5.0 (Unreleased)
 #### Notes
 Added the capability to set a connection timeout when connecting to the HPE OneView Appliance
+
 Extends support of the SDK to OneView Rest API version 600 (OneView v4.0).
 
 #### Features supported with current release:
 - Connection template
+- Enclosure group
+- Ethernet network
 - FC network
 - Interconnect type
 - Logical interconnect group
+- Logical switch
+- SAS interconnect type
 - SAS logical interconnect group
+- Switch type
+- Uplink set
 
 # 4.4.0
 #### Notes

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -70,13 +70,13 @@
 |<sub>/rest/drive-enclosures/{id}/port-map</sub>                                          | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/drive-enclosures/{id}/refreshState</sub>                                      | PUT      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
 |     **Enclosure Groups**                                                                                                                          |
-|<sub>/rest/enclosure-groups</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosure-groups</sub>                                                        | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosure-groups/{id}</sub>                                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosure-groups/{id}</sub>                                                   | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosure-groups/{id}</sub>                                                   | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosure-groups/{id}/script</sub>                                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosure-groups/{id}/script</sub>                                            | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosure-groups</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosure-groups</sub>                                                        | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosure-groups/{id}</sub>                                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosure-groups/{id}</sub>                                                   | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosure-groups/{id}</sub>                                                   | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosure-groups/{id}/script</sub>                                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosure-groups/{id}/script</sub>                                            | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Enclosures**                                                                                                                                |
 |<sub>/rest/enclosures</sub>                                                              | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/enclosures</sub>                                                              | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
@@ -94,15 +94,15 @@
 |<sub>/rest/fc-sans/endpoints</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/fc-sans/endpoints/{id}</sub>                                                  | GET      |  :heavy_minus_sign:  | :heavy_multiplication_x: | :heavy_multiplication_x:
 |     **Ethernet Networks**                                                                                                                         |
-|<sub>/rest/ethernet-networks</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks</sub>                                                       | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/bulk</sub>                                                  | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/{id}</sub>                                                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/{id}</sub>                                                  | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/{id}</sub>                                                  | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark: |
-|<sub>/rest/ethernet-networks/{id}</sub>                                                  | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/{id}/associatedProfiles</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/{id}/associatedUplinkGroups</sub>                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks</sub>                                                       | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/bulk</sub>                                                  | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/{id}</sub>                                                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/{id}</sub>                                                  | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/{id}</sub>                                                  | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :heavy_minus_sign:   |
+|<sub>/rest/ethernet-networks/{id}</sub>                                                  | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/{id}/associatedProfiles</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/{id}/associatedUplinkGroups</sub>                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Events**                                                                                                                         |
 |<sub>/rest/events</sub>                                                                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/events</sub>                                                                  | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
@@ -281,13 +281,13 @@
 |<sub>/rest/logical-switch-groups/{id}</sub>                                              |PUT       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/logical-switch-groups/{id}</sub>                                              |DELETE    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Logical Switches**                                                                                                                         |
-|<sub>/rest/logical-switches</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-switches</sub>                                                        |POST      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-switches/{id}</sub>                                                   |GET       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-switches/{id}</sub>                                                   | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-switches/{id}</sub>                                                   |PUT       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-switches/{id}</sub>                                                   |DELETE    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-switches/{id}/refresh</sub>                                           |PUT       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-switches</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-switches</sub>                                                        |POST      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-switches/{id}</sub>                                                   |GET       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-switches/{id}</sub>                                                   | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-switches/{id}</sub>                                                   |PUT       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-switches/{id}</sub>                                                   |DELETE    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-switches/{id}/refresh</sub>                                           |PUT       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Login Details**                                                                                                                                                   |
 |<sub>/rest/logindetails</sub>                                                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
 |     **Managed SANs**                                                                                                                             |
@@ -372,8 +372,8 @@
 |<sub>/rest/fc-sans/device-managers/{id}</sub>                                            | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/fc-sans/providers/{id}/device-managers</sub>                                  | POST     | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
 |     **SAS Interconnect Types**                                                                                                                   |
-|<sub>/rest/sas-interconnect-types</sub>                                                  | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-interconnect-types/{id}</sub>                                             | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-interconnect-types</sub>                                                  | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-interconnect-types/{id}</sub>                                             | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **SAS Interconnects**                                                                                                                        |
 |<sub>/rest/sas-interconnects</sub>                                                       | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/sas-interconnects/{id}</sub>                                                  | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
@@ -495,8 +495,8 @@
 |<sub>/rest/storage-volume-templates/{id}</sub>                                           | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/storage-volume-templates/{id}/compatible-systems</sub>                        | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :white_check_mark:   |
 |     **Switch Types**                                                                                                                              |
-|<sub>/rest/switch-types</sub>                                                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/switch-types/{id}</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/switch-types</sub>                                                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/switch-types/{id}</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Switches**                                                                                                                                   |
 |<sub>/rest/switches</sub>                                                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/switches/{id}</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
@@ -518,11 +518,11 @@
 |<sub>/rest/unmanaged-devices/{id}</sub>                                                  | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/unmanaged-devices/{id}/environmentalConfiguration</sub>                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Uplink Sets**                                                                                                                              |
-|<sub>/rest/uplink-sets</sub>                                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/uplink-sets</sub>                                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/uplink-sets/{id}</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/uplink-sets/{id}</sub>                                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/uplink-sets/{id}</sub>                                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/uplink-sets</sub>                                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/uplink-sets</sub>                                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/uplink-sets/{id}</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/uplink-sets/{id}</sub>                                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/uplink-sets/{id}</sub>                                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Users**                                                                                                                                   |
 |<sub>/rest/users</sub>                                                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/users</sub>                                                                   | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/examples/enclosure_groups.py
+++ b/examples/enclosure_groups.py
@@ -74,7 +74,7 @@ data = {
 
 # Create a Enclosure Group
 print("Create a Enclosure Group")
-if oneview_client.api_version <=500:
+if oneview_client.api_version <= 500:
     options = {"stackingMode": "Enclosure"}
     options.update(data)
     created_eg = oneview_client.enclosure_groups.create(options)
@@ -95,12 +95,14 @@ if len(result) > 0:
 else:
     print("No Enclosure Group found.")
 
-# Get Enclosure Group by scopeUris
-if oneview_client.api_version ==600:
-    eg_by_scopeuris = oneview_client.enclosure_groups.get_all(scopeUris="\"'/rest/scopes/cd237b60-09e2-45c4-829e-082e318a6d2a'\"")
-    print("Found Enclosure Group by scopeUris: '%s'.\n  uri = '%s'" % (eg_by_scopeuris[0]['name'], eg_by_scopeuris[0]['uri']))
-    pprint(eg_by_scopeuris)
-
+# Get Enclosure Group by scope_uris
+if oneview_client.api_version == 600:
+    eg_by_scope_uris = oneview_client.enclosure_groups.get_all(scope_uris="\"'/rest/scopes/cd237b60-09e2-45c4-829e-082e318a6d2a'\"")
+    if len(eg_by_scope_uris) > 0:
+        print("Found Enclosure Group by scope_uris: '%s'.\n  uri = '%s'" % (eg_by_scope_uris[0]['name'], eg_by_scope_uris[0]['uri']))
+        pprint(eg_by_scope_uris)
+    else:
+        print("No Enclosure Group found.")
 
 # Update an Enclosure Group
 print("Update an Enclosure Group")

--- a/examples/enclosure_groups.py
+++ b/examples/enclosure_groups.py
@@ -43,7 +43,6 @@ oneview_client = OneViewClient(config)
 
 data = {
     "name": "Enclosure Group 1",
-    "stackingMode": "Enclosure",
     "interconnectBayMappings":
         [
             {
@@ -75,7 +74,12 @@ data = {
 
 # Create a Enclosure Group
 print("Create a Enclosure Group")
-created_eg = oneview_client.enclosure_groups.create(data)
+if oneview_client.api_version <=500:
+    options = {"stackingMode": "Enclosure"}
+    options.update(data)
+    created_eg = oneview_client.enclosure_groups.create(options)
+else:
+    created_eg = oneview_client.enclosure_groups.create(data)
 pprint(created_eg)
 
 # Get the first 10 records, sorting by name descending
@@ -91,9 +95,17 @@ if len(result) > 0:
 else:
     print("No Enclosure Group found.")
 
+# Get Enclosure Group by scopeUris
+if oneview_client.api_version ==600:
+    eg_by_scopeuris = oneview_client.enclosure_groups.get_all(scopeUris="\"'/rest/scopes/cd237b60-09e2-45c4-829e-082e318a6d2a'\"")
+    print("Found Enclosure Group by scopeUris: '%s'.\n  uri = '%s'" % (eg_by_scopeuris[0]['name'], eg_by_scopeuris[0]['uri']))
+    pprint(eg_by_scopeuris)
+
+
 # Update an Enclosure Group
 print("Update an Enclosure Group")
-eg_to_update = created_eg.copy()
+result = oneview_client.enclosure_groups.get_by('name', 'Enclosure Group 1')
+eg_to_update = result[0]
 eg_to_update["name"] = "Renamed Enclosure Group"
 updated_eg = oneview_client.enclosure_groups.update(eg_to_update)
 pprint(updated_eg)
@@ -106,7 +118,7 @@ pprint(egs)
 # Get by Id
 try:
     print("Get an Enclosure Group by id")
-    eg_byid = oneview_client.enclosure_groups.get('54184fae-42d5-4248-a732-cfe5115f7857')
+    eg_byid = oneview_client.enclosure_groups.get('293e8efe-c6b1-4783-bf88-2d35a8e49071')
     pprint(eg_byid)
 except HPOneViewException as e:
     print(e.msg)

--- a/examples/ethernet_networks.py
+++ b/examples/ethernet_networks.py
@@ -41,7 +41,7 @@ options = {
     "purpose": "General",
     "smartLink": False,
     "privateNetwork": False,
-    "connectionTemplateUri": None,
+    "connectionTemplateUri": None
 }
 
 options_bulk = {
@@ -53,8 +53,7 @@ options_bulk = {
     "bandwidth": {
         "maximumBandwidth": 10000,
         "typicalBandwidth": 2000
-    },
-    "type": "bulk-ethernet-network"
+    }
 }
 
 # Scope name to perform the patch operation

--- a/hpOneView/resources/networking/ethernet_networks.py
+++ b/hpOneView/resources/networking/ethernet_networks.py
@@ -44,7 +44,14 @@ class EthernetNetworks(object):
     DEFAULT_VALUES = {
         '200': {"type": "ethernet-networkV3"},
         '300': {"type": "ethernet-networkV300"},
-        '500': {"type": "ethernet-networkV300"}
+        '500': {"type": "ethernet-networkV300"},
+        '600': {"type": "ethernet-networkV4"}
+    }
+    BULK_DEFAULT_VALUES = {
+        '200': {"type": "bulk-ethernet-network"},
+        '300': {"type": "bulk-ethernet-network"},
+        '500': {"type": "bulk-ethernet-network"},
+        '600': {"type": "bulk-ethernet-networkV1"}
     }
 
     def __init__(self, con):
@@ -139,10 +146,8 @@ class EthernetNetworks(object):
             list: List of created Ethernet Networks.
 
         """
-        data = {"type": "bulk-ethernet-network"}
-        data.update(resource)
         uri = self.URI + '/bulk'
-        self._client.create(data, uri=uri, timeout=timeout)
+        self._client.create(resource, uri=uri, timeout=timeout,default_values=self.BULK_DEFAULT_VALUES)
 
         return self.get_range(resource['namePrefix'], resource['vlanIdRange'])
 

--- a/hpOneView/resources/networking/ethernet_networks.py
+++ b/hpOneView/resources/networking/ethernet_networks.py
@@ -147,7 +147,7 @@ class EthernetNetworks(object):
 
         """
         uri = self.URI + '/bulk'
-        self._client.create(resource, uri=uri, timeout=timeout,default_values=self.BULK_DEFAULT_VALUES)
+        self._client.create(resource, uri=uri, timeout=timeout, default_values=self.BULK_DEFAULT_VALUES)
 
         return self.get_range(resource['namePrefix'], resource['vlanIdRange'])
 

--- a/hpOneView/resources/networking/logical_switches.py
+++ b/hpOneView/resources/networking/logical_switches.py
@@ -46,7 +46,8 @@ class LogicalSwitches(object):
     SWITCH_DEFAULT_VALUES = {
         '200': {"type": "logical-switch"},
         '300': {"type": "logical-switchV300"},
-        '500': {"type": "logical-switchV300"}
+        '500': {"type": "logical-switchV300"},
+        '600': {"type": "logical-switchV4"}
     }
 
     def __init__(self, con):

--- a/hpOneView/resources/networking/uplink_sets.py
+++ b/hpOneView/resources/networking/uplink_sets.py
@@ -46,7 +46,8 @@ class UplinkSets(object):
     DEFAULT_VALUES = {
         '200': {"type": "uplink-setV3"},
         '300': {"type": "uplink-setV300"},
-        '500': {"type": "uplink-setV300"}
+        '500': {"type": "uplink-setV300"},
+        '600': {"type": "uplink-setV4"}
     }
 
     def __init__(self, con):

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -133,8 +133,6 @@ class ResourceClient(object):
                 the collections or resources).
             fields:
                 Name of the fields.
-            scopeUris:
-                An expression to restrict the resources returned according to the scopes to which they are assigned.
             uri:
                 A specific URI (optional)
             scope_uris:

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -133,6 +133,8 @@ class ResourceClient(object):
                 the collections or resources).
             fields:
                 Name of the fields.
+            scopeUris:
+                An expression to restrict the resources returned according to the scopes to which they are assigned.
             uri:
                 A specific URI (optional)
             scope_uris:

--- a/hpOneView/resources/servers/enclosure_groups.py
+++ b/hpOneView/resources/servers/enclosure_groups.py
@@ -51,7 +51,7 @@ class EnclosureGroups(object):
         self._connection = con
         self._client = ResourceClient(con, self.URI)
 
-    def get_all(self, start=0, count=-1, filter='', sort=''):
+    def get_all(self, start=0, count=-1, filter='', sort='', scopeUris=''):
         """
         Gets a list of enclosure groups.
 
@@ -69,11 +69,14 @@ class EnclosureGroups(object):
             sort:
                 The sort order of the returned data set. By default, the sort order is based
                 on create time with the oldest entry first.
+            scopeUris:
+                An expression to restrict the resources returned according to the scopes to
+                which they are assigned.
 
         Returns:
             list: A list of enclosure groups.
         """
-        return self._client.get_all(start, count, filter=filter, sort=sort)
+        return self._client.get_all(start, count, filter=filter, sort=sort, scopeUris=scopeUris)
 
     def get(self, id_or_uri):
         """

--- a/hpOneView/resources/servers/enclosure_groups.py
+++ b/hpOneView/resources/servers/enclosure_groups.py
@@ -51,7 +51,7 @@ class EnclosureGroups(object):
         self._connection = con
         self._client = ResourceClient(con, self.URI)
 
-    def get_all(self, start=0, count=-1, filter='', sort='', scopeUris=''):
+    def get_all(self, start=0, count=-1, filter='', sort='', scope_uris=''):
         """
         Gets a list of enclosure groups.
 
@@ -69,14 +69,14 @@ class EnclosureGroups(object):
             sort:
                 The sort order of the returned data set. By default, the sort order is based
                 on create time with the oldest entry first.
-            scopeUris:
+            scope_uris:
                 An expression to restrict the resources returned according to the scopes to
                 which they are assigned.
 
         Returns:
             list: A list of enclosure groups.
         """
-        return self._client.get_all(start, count, filter=filter, sort=sort, scopeUris=scopeUris)
+        return self._client.get_all(start, count, filter=filter, sort=sort, scope_uris=scope_uris)
 
     def get(self, id_or_uri):
         """

--- a/tests/unit/resources/networking/test_ethernet_networks.py
+++ b/tests/unit/resources/networking/test_ethernet_networks.py
@@ -54,7 +54,6 @@ class EthernetNetworksTest(TestCase):
             "purpose": "Management",
             "connectionTemplateUri": None,
             "smartLink": False,
-            "type": "ethernet-networkV3",
             "privateNetwork": False
         }
         resource_rest_call = resource.copy()
@@ -89,8 +88,7 @@ class EthernetNetworksTest(TestCase):
             'bandwidth': {
                 'maximumBandwidth': 10000,
                 'typicalBandwidth': 2000
-            },
-            'type': 'bulk-ethernet-network'
+            }
         }
         resource_rest_call = resource.copy()
         mock_create.return_value = {}
@@ -99,7 +97,7 @@ class EthernetNetworksTest(TestCase):
         self._ethernet_networks.create_bulk(resource, 27)
 
         mock_create.assert_called_once_with(
-            resource_rest_call, uri='/rest/ethernet-networks/bulk', timeout=27)
+            resource_rest_call, uri='/rest/ethernet-networks/bulk', timeout=27, default_values=self._ethernet_networks.BULK_DEFAULT_VALUES)
         mock_get_all.assert_called_once_with(
             0, -1, filter='"\'name\' matches \'TestNetwork\\_%\'"', sort='vlanId:ascending')
 
@@ -112,7 +110,6 @@ class EthernetNetworksTest(TestCase):
             'vlanId': None,
             'privateNetwork': True,
             'ethernetNetworkType': 'Untagged',
-            'type': 'ethernet-networkV3',
             'purpose': 'General'
         }
         resource_rest_call = resource.copy()

--- a/tests/unit/resources/servers/test_enclosure_groups.py
+++ b/tests/unit/resources/servers/test_enclosure_groups.py
@@ -72,15 +72,15 @@ class EnclosureGroupsTest(unittest.TestCase):
     def test_get_all_called_once(self, mock_get_all):
         filter = 'name=TestName'
         sort = 'name:ascending'
+        scope_uris = 'rest/scopes/cd237b60-09e2-45c4-829e-082e318a6d2a'
+        self.client.get_all(2, 500, filter, sort, scope_uris)
 
-        self.client.get_all(2, 500, filter, sort)
-
-        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort)
+        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort, scope_uris=scope_uris)
 
     @mock.patch.object(ResourceClient, 'get_all')
     def test_get_all_called_once_with_default(self, mock_get_all):
         self.client.get_all()
-        mock_get_all.assert_called_once_with(0, -1, filter='', sort='')
+        mock_get_all.assert_called_once_with(0, -1, filter='', sort='', scope_uris='')
 
     @mock.patch.object(ResourceClient, 'get')
     def test_get_by_id_called_once(self, mock_get):


### PR DESCRIPTION
### Description
Extending SDK support for REST Api600 for following resources:
- Enclosure Groups
- Ethernet Networks
- Logical Switches
- Uplink Sets
- Sas Interconnect types
- Switch types

### Issues Resolved
[List any issues this PR will resolve. e.g., Fixes #01]

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [X] New endpoints supported are updated in the endpoints-support.md file.
- [X] Changes are documented in the CHANGELOG.