### PR TITLE
Upgrade/600/fcoe networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Extends support of the SDK to OneView Rest API version 600 (OneView v4.0).
 #### Features supported with current release:
 - Connection template
 - FC network
+- FCoE Networks
 - Interconnect type
 - Logical interconnect group
 - SAS logical interconnect group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Extends support of the SDK to OneView Rest API version 600 (OneView v4.0).
 #### Features supported with current release:
 - Connection template
 - FC network
-- FCoE Networks
+- FCoE network
 - Interconnect type
 - Logical interconnect group
 - SAS logical interconnect group

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -120,12 +120,12 @@
 |<sub>/rest/fc-networks/{id}</sub>                                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/fc-networks/{id}</sub>                                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **FCoE Networks**                                                                                                                             |
-|<sub>/rest/fcoe-networks</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fcoe-networks</sub>                                                           | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fcoe-networks/{id}</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fcoe-networks/{id}</sub>                                                      | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark: |
-|<sub>/rest/fcoe-networks/{id}</sub>                                                      | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fcoe-networks/{id}</sub>                                                      | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fcoe-networks</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/fcoe-networks</sub>                                                           | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/fcoe-networks/{id}</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/fcoe-networks/{id}</sub>                                                      | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark: |   :heavy_minus_sign:
+|<sub>/rest/fcoe-networks/{id}</sub>                                                      | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/fcoe-networks/{id}</sub>                                                      | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
 |     **Firmware Bundles**                                                                                                                          |
 |<sub>/rest/firmware-bundles</sub>                                                       | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Firmware Drivers**                                                                                                                          |
@@ -326,7 +326,7 @@
 |<sub>/rest/os-deployment-servers/image-streamer-appliances</sub>                         | GET      | :heavy_minus_sign:   | :white_check_mark:   |                      |
 |<sub>/rest/os-deployment-servers/image-streamer-appliances/{id}</sub>                    | GET      | :heavy_minus_sign:   | :white_check_mark:   |                      |
 |<sub>/rest/os-deployment-servers/network</sub>                                           | GET      | :heavy_minus_sign:   | :white_check_mark:   |                      |
-|<sub>/rest/deployment-servers/security-mode/security-compatibility-checker</sub>         | POST     | :heavy_minus_sign:   | :heavy_minus_sign:   |                       
+|<sub>/rest/deployment-servers/security-mode/security-compatibility-checker</sub>         | POST     | :heavy_minus_sign:   | :heavy_minus_sign:   |
 |<sub>/rest/os-deployment-servers/{id}</sub>                                              | GET      | :heavy_minus_sign:   | :white_check_mark:   |                      |
 |<sub>/rest/os-deployment-servers/{id}</sub>                                              | PUT      | :heavy_minus_sign:   | :white_check_mark:   |                      |
 |<sub>/rest/os-deployment-servers/{id}</sub>                                              | DELETE   | :heavy_minus_sign:   | :white_check_mark:   |                      |

--- a/hpOneView/resources/networking/fcoe_networks.py
+++ b/hpOneView/resources/networking/fcoe_networks.py
@@ -45,7 +45,7 @@ class FcoeNetworks(object):
         '200': {"type": "fcoe-network"},
         '300': {"type": "fcoe-networkV300"},
         '500': {"type": "fcoe-networkV300"},
-        '600': {"type": "fcoe-networkV4"} 
+        '600': {"type": "fcoe-networkV4"}
     }
 
     def __init__(self, con):

--- a/hpOneView/resources/networking/fcoe_networks.py
+++ b/hpOneView/resources/networking/fcoe_networks.py
@@ -44,7 +44,8 @@ class FcoeNetworks(object):
     DEFAULT_VALUES = {
         '200': {"type": "fcoe-network"},
         '300': {"type": "fcoe-networkV300"},
-        '500': {"type": "fcoe-networkV300"}
+        '500': {"type": "fcoe-networkV300"},
+        '600': {"type": "fcoe-networkV4"} 
     }
 
     def __init__(self, con):


### PR DESCRIPTION
Extending support of the SDK to OneView Rest API version 600.
Resources :
  1. FCoE Networks.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
