### PR TITLE
Api600 server hardware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Extends support of the SDK to OneView Rest API version 600 (OneView v4.0).
 - SAS interconnect type
 - SAS logical interconnect
 - SAS logical interconnect group
+- Server hardware
 - Switch type
 - Uplink set
 

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -413,24 +413,25 @@
 |<sub>/rest/scopes/{id}</sub>                                                             | DELETE   | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/scopes/{id}/resource-assignments</sub>                                        | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :heavy_minus_sign:   |
 |     **Server Hardware**                                                                                                                          |
-|<sub>/rest/server-hardware</sub>                                                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware</sub>                                                         | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}</sub>                                                    | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}</sub>                                                    | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/bios</sub>                                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/environmentalConfiguration</sub>                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/environmentalConfiguration</sub>                         | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/iloSsoUrl</sub>                                          | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/javaRemoteConsoleUrl</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/mpFirmwareVersion</sub>                                  | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/physicalServerHardware</sub>                             | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/powerState</sub>                                         | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/refreshState</sub>                                       | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/remoteConsoleUrl</sub>                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/utilization</sub>                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}                                                          | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/*/firmware                                                    | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/firmware                                                 | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware</sub>                                                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware</sub>                                                         | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}</sub>                                                    | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}</sub>                                                    | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/bios</sub>                                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/environmentalConfiguration</sub>                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/environmentalConfiguration</sub>                         | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/iloSsoUrl</sub>                                          | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/javaRemoteConsoleUrl</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/mpFirmwareVersion</sub>                                  | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/physicalServerHardware</sub>                             | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/powerState</sub>                                         | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/refreshState</sub>                                       | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/remoteConsoleUrl</sub>                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/utilization</sub>                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}                                                          | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/*/firmware                                                    | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/firmware                                                 | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/discovery                                                     | POST     | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :white_check_mark:   |
 |     **Server Hardware Types**                                                                                                                     |
 |<sub>/rest/server-hardware-types</sub>                                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-hardware-types/{id}</sub>                                              | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/examples/server_hardware.py
+++ b/examples/server_hardware.py
@@ -84,14 +84,14 @@ print("Added rack mount server '%s'.\n  uri = '%s'" %
 
 # Create Multiple rack-mount servers
 if oneview_client.api_version >= 600:
-    options_to_add_mult = {
+    options_to_add_multiple_server = {
         "mpHostsAndRanges": config['server_mpHostsAndRanges'],
         "username": config['server_username'],
         "password": config['server_password'],
         "licensingIntent": "OneView",
         "configurationState": "Managed",
     }
-    server_mult = oneview_client.server_hardware.add_multiple(options_to_add_mult)
+    multiple_server = oneview_client.server_hardware.add_multiple_servers(options_to_add_multiple_server)
 else:
     print("\nCANNOT CREATE MULTIPLE SERVERS! Endpoint supported for REST API Versions 600 and above only.\n")
 

--- a/examples/server_hardware.py
+++ b/examples/server_hardware.py
@@ -90,7 +90,6 @@ if oneview_client.api_version >= 600:
         "password": config['server_password'],
         "licensingIntent": "OneView",
         "configurationState": "Managed",
-        "initialScopeUris": ["/rest/scopes/7a7db914-ca1d-4112-9189-4ce1a4774ce3"]
     }
     server_mult = oneview_client.server_hardware.add_multiple(options_to_add_mult)
 else:

--- a/examples/server_hardware.py
+++ b/examples/server_hardware.py
@@ -92,10 +92,9 @@ if oneview_client.api_version >= 600:
         "configurationState": "Managed",
         "initialScopeUris": ["/rest/scopes/7a7db914-ca1d-4112-9189-4ce1a4774ce3"]
     }
-    try:
-        server_mult = oneview_client.server_hardware.add_multiple(options2)
-    except HPOneViewException as e:
-        print(e.msg)
+    server_mult = oneview_client.server_hardware.add_multiple(options_to_add_mult)
+else:
+    print("\nCANNOT CREATE MULTIPLE SERVERS! Endpoint supported for REST API Versions 600 and above only.\n")
 
 # Get recently added server hardware resource by uri
 server_byId = oneview_client.server_hardware.get(server['uri'])

--- a/examples/server_hardware.py
+++ b/examples/server_hardware.py
@@ -47,7 +47,7 @@ options = {
 
 # Set the server_hardware_id to run this example.
 # server_hardware_id example: 37333036-3831-4753-4831-30315838524E
-server_hardware_id = "34323937-3431-4732-3230-313130364747"
+server_hardware_id = "30303437-3034-4D32-3230-313133334752"
 
 oneview_client = OneViewClient(config)
 
@@ -81,6 +81,21 @@ for serv in server_hardware_all:
 server = oneview_client.server_hardware.add(options)
 print("Added rack mount server '%s'.\n  uri = '%s'" %
       (server['name'], server['uri']))
+
+# Create Multiple rack-mount servers
+if oneview_client.api_version >= 600:
+    options_to_add_mult = {
+        "mpHostsAndRanges": config['server_mpHostsAndRanges'],
+        "username": config['server_username'],
+        "password": config['server_password'],
+        "licensingIntent": "OneView",
+        "configurationState": "Managed",
+        "initialScopeUris": ["/rest/scopes/7a7db914-ca1d-4112-9189-4ce1a4774ce3"]
+    }
+    try:
+        server_mult = oneview_client.server_hardware.add_multiple(options2)
+    except HPOneViewException as e:
+        print(e.msg)
 
 # Get recently added server hardware resource by uri
 server_byId = oneview_client.server_hardware.get(server['uri'])

--- a/hpOneView/resources/servers/server_hardware.py
+++ b/hpOneView/resources/servers/server_hardware.py
@@ -174,6 +174,27 @@ class ServerHardware(object):
         """
         return self._client.create(information, timeout=timeout)
 
+    def add_multiple(self, information, timeout=-1):
+        """
+        Adds multiple rackmount servers for management by the appliance. This API initiates the asynchronous addition of
+        supported server models.
+
+        Note: Servers in an enclosure are added by adding the enclosure resource. This is
+        only supported on appliances that support rackmounted servers.
+
+        This is only supported for api version 600
+
+        Args:
+            information (dict): Objects to create
+            timeout: Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
+                in OneView; it just stops waiting for its completion.
+
+        Returns:
+            dict: Created rackmount servers.
+        """
+        uri = self._client.build_uri(self.URI) + "/discovery"
+        return self._client.create(information, uri=uri, timeout=timeout)
+
     def get(self, id_or_uri):
         """
         Gets a server hardware resource by ID or by URI.

--- a/hpOneView/resources/servers/server_hardware.py
+++ b/hpOneView/resources/servers/server_hardware.py
@@ -174,7 +174,7 @@ class ServerHardware(object):
         """
         return self._client.create(information, timeout=timeout)
 
-    def add_multiple(self, information, timeout=-1):
+    def add_multiple_servers(self, information, timeout=-1):
         """
         Adds multiple rack-mount servers for management by the appliance. This API initiates the asynchronous addition of
         supported server models.

--- a/hpOneView/resources/servers/server_hardware.py
+++ b/hpOneView/resources/servers/server_hardware.py
@@ -158,11 +158,11 @@ class ServerHardware(object):
 
     def add(self, information, timeout=-1):
         """
-        Adds a rackmount server for management by the appliance. This API initiates the asynchronous addition of
+        Adds a rack-mount server for management by the appliance. This API initiates the asynchronous addition of
         supported server models.
 
         Note: Servers in an enclosure are added by adding the enclosure resource. This is
-        only supported on appliances that support rackmounted servers.
+        only supported on appliances that support rack-mounted servers.
 
         Args:
             information (dict): Object to create
@@ -170,17 +170,17 @@ class ServerHardware(object):
                 in OneView; it just stops waiting for its completion.
 
         Returns:
-            dict: Created rackmount server.
+            dict: Created rack-mount server.
         """
         return self._client.create(information, timeout=timeout)
 
     def add_multiple(self, information, timeout=-1):
         """
-        Adds multiple rackmount servers for management by the appliance. This API initiates the asynchronous addition of
+        Adds multiple rack-mount servers for management by the appliance. This API initiates the asynchronous addition of
         supported server models.
 
         Note: Servers in an enclosure are added by adding the enclosure resource. This is
-        only supported on appliances that support rackmounted servers.
+        only supported on appliances that support rack-mounted servers.
 
         This is only supported for api version 600
 
@@ -190,7 +190,7 @@ class ServerHardware(object):
                 in OneView; it just stops waiting for its completion.
 
         Returns:
-            dict: Created rackmount servers.
+            dict: Created rack-mount servers.
         """
         uri = self._client.build_uri(self.URI) + "/discovery"
         return self._client.create(information, uri=uri, timeout=timeout)
@@ -225,7 +225,7 @@ class ServerHardware(object):
     def remove(self, resource, force=False, timeout=-1):
         """
         Removes the rackserver with the specified URI.
-        Note: This operation is only supported on appliances that support rackmounted servers.
+        Note: This operation is only supported on appliances that support rack-mounted servers.
 
         Args:
             resource (dict):

--- a/tests/unit/resources/servers/test_server_hardware.py
+++ b/tests/unit/resources/servers/test_server_hardware.py
@@ -87,15 +87,16 @@ class ServerHardwareTest(TestCase):
         mock_create.assert_called_once_with(information.copy(), timeout=-1)
 
     @mock.patch.object(ResourceClient, 'create')
-    def test_add_multiple_called_once(self, mock_create):
+    def test_add_multiple_servers_called_once(self, mock_create):
+        uri = "/rest/server-hardware/discovery"
         information = {
             "licensingIntent": "OneView",
             "configurationState": "Managed"
         }
         mock_create.return_value = {}
 
-        self._server_hardware.add_multiple(information)
-        mock_create.assert_called_once_with(information.copy(), timeout=-1, uri="/rest/server-hardware/discovery")
+        self._server_hardware.add_multiple_servers(information)
+        mock_create.assert_called_once_with(information.copy(), timeout=-1, uri=uri)
 
     @mock.patch.object(ResourceClient, 'get')
     def test_get_called_once(self, mock_get):

--- a/tests/unit/resources/servers/test_server_hardware.py
+++ b/tests/unit/resources/servers/test_server_hardware.py
@@ -86,6 +86,17 @@ class ServerHardwareTest(TestCase):
         self._server_hardware.add(information)
         mock_create.assert_called_once_with(information.copy(), timeout=-1)
 
+    @mock.patch.object(ResourceClient, 'create')
+    def test_add_multiple_called_once(self, mock_create):
+        information = {
+            "licensingIntent": "OneView",
+            "configurationState": "Managed"
+        }
+        mock_create.return_value = {}
+
+        self._server_hardware.add_multiple(information)
+        mock_create.assert_called_once_with(information.copy(), timeout=-1, uri="/rest/server-hardware/discovery")
+
     @mock.patch.object(ResourceClient, 'get')
     def test_get_called_once(self, mock_get):
         self._server_hardware.get('3518be0e-17c1-4189-8f81-83f3724f6155')


### PR DESCRIPTION
### Extending api600 support
PR to extend support of the resource server-hardware for api600

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [X] New endpoints supported are updated in the endpoints-support.md file.
- [X] Changes are documented in the CHANGELOG.
