### PR TITLE
api600_switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Extends support of the SDK to OneView Rest API version 600 (OneView v4.0).
 - SAS logical interconnect
 - SAS logical interconnect group
 - Server hardware
+- Switch
 - Switch type
 - Tasks
 - Uplink set

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -502,14 +502,14 @@
 |<sub>/rest/switch-types</sub>                                                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/switch-types/{id}</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Switches**                                                                                                                                   |
-|<sub>/rest/switches</sub>                                                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/switches/{id}</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/switches/{id}</sub>                                                           | PATCH    | :heavy_minus_sign:   | :heavy_minus_sign:   | :white_check_mark:   |
-|<sub>/rest/switches/{id}</sub>                                                           | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/switches/{id}/environmentalConfiguration</sub>                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/switches/{id}/statistics</sub>                                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/switches/{id}/statistics/{portName:.+}</sub>                                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/switches/{id}/update-ports</sub>                                              | PUT      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/switches</sub>                                                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/switches/{id}</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/switches/{id}</sub>                                                           | PATCH    | :heavy_minus_sign:   | :heavy_minus_sign:   | :white_check_mark:   | :heavy_minus_sign:   |
+|<sub>/rest/switches/{id}</sub>                                                           | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/switches/{id}/environmentalConfiguration</sub>                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/switches/{id}/statistics</sub>                                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/switches/{id}/statistics/{portName:.+}</sub>                                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/switches/{id}/update-ports</sub>                                              | PUT      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Tasks**                                                                                                                                     |
 |<sub>/rest/tasks</sub>                                                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/tasks/{id}</sub>                                                              | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/examples/switches.py
+++ b/examples/switches.py
@@ -109,7 +109,7 @@ print("\nTrying to retrieve scope named '%s'." % scope_name)
 scope = oneview_client.scopes.get_by_name(scope_name)
 
 # Performs a patch operation on the Logical Switch
-if scope:
+if scope and oneview_client.api_version == 500:
     print("\nPatches the switch assigning the '%s' scope to it." % scope_name)
     switch_by_uri = oneview_client.switches.patch(switch_by_uri['uri'],
                                                   'replace',
@@ -131,3 +131,11 @@ if oneview_client.api_version >= 300:
         print("  Done.")
     except HPOneViewException as e:
         print(e.msg)
+
+# Delete the migrated switch
+print("\nDelete a switch:\n")
+try:
+    oneview_client.switches.delete(switch_by_id)
+    print("Successfully deleted the switch")
+except HPOneViewException as e:
+    print(e.msg)


### PR DESCRIPTION
Extending SDK support for OneView API version:600

Resource:
Switches

### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [X] New endpoints supported are updated in the endpoints-support.md file.
- [X] Changes are documented in the CHANGELOG.
