### PR TITLE
Fix issue#353 - Python-Future link error on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ by the way you expect to work, with a single integrated view of your IT
 infrastructure.
 
 The HPE OneView Python library depends on the
-[Python-Future](http://python-future.org/index.htm) library to provide Python
+[Python-Future](http://python-future.org/index.html) library to provide Python
 2/3 compatibility. This will be installed automatically if you use the installation
 methods described below.
 


### PR DESCRIPTION
Correcting the link in README.md file to `python-future` module homepage.

### Issues Resolved
- Issue#353 - Python-Future link error on README.md 

### Check List
- [] New functionality includes testing.
  - [] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [X] New functionality has been documented in the README if applicable.
  - [] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [] New endpoints supported are updated in the endpoints-support.md file.
- [] Changes are documented in the CHANGELOG.
