### PR TITLE
Upgrade/600/server profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ Extends support of the SDK to OneView Rest API version 600 (OneView v4.0).
 - SAS logical interconnect
 - SAS logical interconnect group
 - Server hardware
+- Server profile
 - Server profile template
 - Switch
-- Server profile
 - Switch type
 - Tasks
 - Uplink set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Extends support of the SDK to OneView Rest API version 600 (OneView v4.0).
 - Server hardware
 - Server profile template
 - Switch
+- Server profile
 - Switch type
 - Tasks
 - Uplink set

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -447,23 +447,23 @@
 |<sub>/rest/server-profile-templates/{id}/transformation</sub>                            | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
 |<sub>/rest/server-profile-templates/available-networks</sub>                             | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :white_check_mark:
 |     **Server Profiles**                                                                                                                           |
-|<sub>/rest/server-profiles</sub>                                                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles</sub>                                                         | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles</sub>                                                         | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/available-networks</sub>                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/available-servers</sub>                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/available-storage-system</sub>                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/available-storage-systems</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/available-targets</sub>                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/profile-ports</sub>                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/{id}</sub>                                                    | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/{id}</sub>                                                    | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/{id}</sub>                                                    | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/{id}</sub>                                                    | PATCH    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/{id}/compliance-preview</sub>                                 | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/{id}/new-profile-template</sub>                               | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/{id}/messages</sub>                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/{id}/transformation</sub>                                     | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profiles</sub>                                                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/server-profiles</sub>                                                         | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/server-profiles</sub>                                                         | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/server-profiles/available-networks</sub>                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/server-profiles/available-servers</sub>                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/server-profiles/available-storage-system</sub>                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :heavy_minus_sign:
+|<sub>/rest/server-profiles/available-storage-systems</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :heavy_minus_sign:
+|<sub>/rest/server-profiles/available-targets</sub>                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/server-profiles/profile-ports</sub>                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/server-profiles/{id}</sub>                                                    | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/server-profiles/{id}</sub>                                                    | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/server-profiles/{id}</sub>                                                    | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/server-profiles/{id}</sub>                                                    | PATCH    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/server-profiles/{id}/compliance-preview</sub>                                 | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/server-profiles/{id}/new-profile-template</sub>                               | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/server-profiles/{id}/messages</sub>                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :heavy_minus_sign:
+|<sub>/rest/server-profiles/{id}/transformation</sub>                                     | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
 |     **Storage Pools**                                                                                                                            |
 |<sub>/rest/storage-pools</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/storage-pools</sub>                                                           | POST     | :white_check_mark:   | :white_check_mark:   | :heavy_minus_sign:   |

--- a/examples/server_profiles.py
+++ b/examples/server_profiles.py
@@ -109,10 +109,12 @@ print("\nGet a server profile by uri")
 profile = oneview_client.server_profiles.get(profile_uri)
 pprint(profile)
 
-# Retrieve ServerProfile schema
-print("\nRetrieve the generated ServerProfile schema")
-schema = oneview_client.server_profiles.get_schema()
-pprint(schema)
+if oneview_client.api_version <= 500:
+    # Retrieve ServerProfile schema
+    # This method available only for API version <= 500
+    print("\nRetrieve the generated ServerProfile schema")
+    schema = oneview_client.server_profiles.get_schema()
+    pprint(schema)
 
 try:
     # Server profile compliance preview

--- a/hpOneView/resources/servers/server_profiles.py
+++ b/hpOneView/resources/servers/server_profiles.py
@@ -61,7 +61,7 @@ class ServerProfiles(object):
             resource (dict): Object to create.
             timeout: Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
                 in OneView, just stop waiting for its completion.
-            force (Query Parameter): Comma separated list of flags for ignoring specific warning.
+            force: Comma separated list of flags for ignoring specific warning.
 
         Returns:
             dict: Created server profile.
@@ -76,7 +76,7 @@ class ServerProfiles(object):
         Args:
             id_or_uri: Can be either the server profile id or the server profile uri.
             resource (dict): Object to update.
-            force (Query Parameter): Comma separated list of flags for ignoring specific warning.
+            force: Comma separated list of flags for ignoring specific warning.
 
         Returns:
             dict: The server profile resource.
@@ -312,24 +312,23 @@ class ServerProfiles(object):
         server profile, along with their respective ports.
 
         Args:
-           enclosureGroupUri (str):
-               The URI of the enclosure group associated with the resource.
-           functionType (str):
-               The FunctionType (Ethernet or FibreChannel) to filter the list of networks returned.
-           serverHardwareTypeUri (str):
-               The URI of the server hardware type associated with the resource.
-           serverHardwareUri (str):
-               The URI of the server hardware associated with the resource.
-           view (str):
-               Returns a specific subset of the attributes of the resource or collection, by specifying the name of a
-               predefined view. The default view is expand (show all attributes of the resource and all elements of
-               collections of resources).
+           enclosureGroupUri (str): The URI of the enclosure group associated with the resource.
+           functionType (str): The FunctionType (Ethernet or FibreChannel) to filter the list of networks returned.
+           serverHardwareTypeUri (str): The URI of the server hardware type associated with the resource.
+           serverHardwareUri (str): The URI of the server hardware associated with the resource.
+           view (str): Returns a specific subset of the attributes of the resource or collection, by
+               specifying the name of a predefined view. The default view is expand (show all attributes
+               of the resource and all elements of collections of resources).
 
                Values:
                    Ethernet
                        Specifies that the connection is to an Ethernet network or a network set.
                    FibreChannel
                        Specifies that the connection is to a Fibre Channel network.
+           profileUri (str): If the URI of the server profile is provided the list of available networks will
+               include only networks that share a scope with the server profile.
+           scopeUris (str): An expression to restrict the resources returned according to the scopes
+               to which they are assigned
 
         Returns:
             list: Available networks.
@@ -342,12 +341,11 @@ class ServerProfiles(object):
         Retrieves the list of available servers.
 
         Args:
-           enclosureGroupUri (str):
-               The URI of the enclosure group associated with the resource.
-           serverHardwareTypeUri (str):
-               The URI of the server hardware type associated with the resource.
-           profileUri (str):
-               The URI of the server profile resource.
+           enclosureGroupUri (str): The URI of the enclosure group associated with the resource.
+           serverHardwareTypeUri (str): The URI of the server hardware type associated with the resource.
+           profileUri (str): The URI of the server profile resource.
+           scopeUris (str): An expression to restrict the resources returned according to
+               the scopes to which they are assigned.
 
         Returns:
             list: Available servers.
@@ -410,12 +408,11 @@ class ServerProfiles(object):
         profile.
 
         Args:
-           enclosureGroupUri (str):
-               The URI of the enclosure group associated with the resource.
-           serverHardwareTypeUri (str):
-               The URI of the server hardware type associated with the resource.
-           profileUri (str):
-               The URI of the server profile associated with the resource.
+           enclosureGroupUri (str): The URI of the enclosure group associated with the resource.
+           serverHardwareTypeUri (str): The URI of the server hardware type associated with the resource.
+           profileUri (str): The URI of the server profile associated with the resource.
+           scopeUris (str): An expression to restrict the resources returned according to
+               the scopes to which they are assigned.
 
         Returns:
             list: List of available servers and bays.

--- a/hpOneView/resources/servers/server_profiles.py
+++ b/hpOneView/resources/servers/server_profiles.py
@@ -66,7 +66,7 @@ class ServerProfiles(object):
         Returns:
             dict: Created server profile.
         """
-        uri = self.__build_uri_with_query_string({"force":force})
+        uri = self.__build_uri_with_query_string({"force": force})
         return self._client.create(resource=resource, uri=uri, timeout=timeout, default_values=self.DEFAULT_VALUES)
 
     def update(self, resource, id_or_uri, force=''):
@@ -423,7 +423,7 @@ class ServerProfiles(object):
         uri = self.__build_uri_with_query_string(kwargs, '/available-targets')
         return self._client.get(uri)
 
-    def __build_uri_with_query_string(self, kwargs, sufix_path, id_or_uri=None):
+    def __build_uri_with_query_string(self, kwargs, sufix_path='', id_or_uri=None):
         uri = self.URI
         if id_or_uri:
             uri = self._client.build_uri(id_or_uri)

--- a/hpOneView/resources/servers/server_profiles.py
+++ b/hpOneView/resources/servers/server_profiles.py
@@ -44,14 +44,16 @@ class ServerProfiles(object):
     DEFAULT_VALUES = {
         '200': {"type": "ServerProfileV5"},
         '300': {"type": "ServerProfileV6"},
-        '500': {"type": "ServerProfileV7"}
+        '500': {"type": "ServerProfileV7"},
+        '600': {"type": "ServerProfileV8"},
+
     }
 
     def __init__(self, con):
         self._connection = con
         self._client = ResourceClient(con, self.URI)
 
-    def create(self, resource, timeout=-1):
+    def create(self, resource, timeout=-1, force=''):
         """
         Creates a server profile using the information provided in the resource parameter.
 
@@ -59,19 +61,22 @@ class ServerProfiles(object):
             resource (dict): Object to create.
             timeout: Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
                 in OneView, just stop waiting for its completion.
+            force (Query Parameter): Comma separated list of flags for ignoring specific warning.
 
         Returns:
             dict: Created server profile.
         """
-        return self._client.create(resource=resource, timeout=timeout, default_values=self.DEFAULT_VALUES)
+        uri = self.__build_uri_with_query_string({"force":force})
+        return self._client.create(resource=resource, uri=uri, timeout=timeout, default_values=self.DEFAULT_VALUES)
 
-    def update(self, resource, id_or_uri):
+    def update(self, resource, id_or_uri, force=''):
         """
         Allows the configuration of a server profile object to be modified.
 
         Args:
             id_or_uri: Can be either the server profile id or the server profile uri.
             resource (dict): Object to update.
+            force (Query Parameter): Comma separated list of flags for ignoring specific warning.
 
         Returns:
             dict: The server profile resource.
@@ -80,7 +85,9 @@ class ServerProfiles(object):
         if resource.get('serverHardwareUri') is None:
             resource.pop('enclosureBay', None)
             resource.pop('enclosureUri', None)
-        return self._client.update(resource=resource, uri=id_or_uri, default_values=self.DEFAULT_VALUES)
+
+        uri = self. __build_uri_with_query_string({'force': force}, id_or_uri=id_or_uri)
+        return self._client.update(resource=resource, uri=uri, default_values=self.DEFAULT_VALUES)
 
     def patch(self, id_or_uri, operation, path, value, timeout=-1):
         """

--- a/tests/unit/resources/servers/test_server_profiles.py
+++ b/tests/unit/resources/servers/test_server_profiles.py
@@ -70,24 +70,28 @@ class ServerProfilesTest(TestCase):
 
     @mock.patch.object(ResourceClient, 'create')
     def test_create(self, mock_create):
+        force = ""
+        uri = "/rest/server-profiles?force=%s" % (force)
         template = dict(name="Server Profile Test")
 
         expected_template = template.copy()
 
         self._resource.create(resource=template, timeout=TIMEOUT)
-        mock_create.assert_called_once_with(resource=expected_template, timeout=TIMEOUT,
+        mock_create.assert_called_once_with(resource=expected_template, uri=uri, timeout=TIMEOUT,
                                             default_values=self._resource.DEFAULT_VALUES)
 
     @mock.patch.object(ResourceClient, 'update')
     def test_update(self, mock_update):
+        force = ""
         uri = "/rest/server-profiles/4ff2327f-7638-4b66-ad9d-283d4940a4ae"
+        rest_uri = "/rest/server-profiles/4ff2327f-7638-4b66-ad9d-283d4940a4ae?force=%s" % (force)
         template = dict(name="Server Profile Test", macType="Virtual",
                         enclosureUri='/rest/fake', enclosureBay=3)
 
         expected_template = dict(name="Server Profile Test", macType="Virtual")
 
         self._resource.update(resource=template, id_or_uri=uri)
-        mock_update.assert_called_once_with(resource=expected_template, uri=uri,
+        mock_update.assert_called_once_with(resource=expected_template, uri=rest_uri,
                                             default_values=self._resource.DEFAULT_VALUES)
 
     @mock.patch.object(ResourceClient, 'delete')


### PR DESCRIPTION
Extending SDK support for OneView API version 600.

Resources;
  Server Profile

### Check List
- [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [x] Changes are documented in the CHANGELOG.
