### PR TITLE
Api600 support for Logical Enclosure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Extends support of the SDK to OneView Rest API version 600 (OneView v4.0).
 - FCoE network
 - Interconnect type
 - Internal link set
+- Logical enclosure
 - Logical interconnect
 - Logical interconnect group
 - Logical switch

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -227,17 +227,17 @@
 |<sub>/rest/logical-downlinks/withoutEthernet</sub>                                       |GET       | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
 |<sub>/rest/logical-downlinks/{id}/withoutEthernet</sub>                                  |GET       | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
 |     **Logical Enclosures**                                                                                                                        |
-|<sub>/rest/logical-enclosures</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures</sub>                                                      | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}</sub>                                                 | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}</sub>                                                 | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}</sub>                                                 | PATCH    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}</sub>                                                 | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}/configuration</sub>                                   | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}/script</sub>                                          | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}/script</sub>                                          | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}/support-dumps</sub>                                   | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}/updateFromGroup</sub>                                 | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures</sub>                                                      | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}</sub>                                                 | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}</sub>                                                 | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}</sub>                                                 | PATCH    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}</sub>                                                 | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}/configuration</sub>                                   | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}/script</sub>                                          | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}/script</sub>                                          | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}/support-dumps</sub>                                   | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}/updateFromGroup</sub>                                 | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Logical Interconnect Groups**                                                                                                               |
 |<sub>/rest/logical-interconnect-groups</sub>                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/logical-interconnect-groups</sub>                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/examples/logical_enclosures.py
+++ b/examples/logical_enclosures.py
@@ -60,7 +60,7 @@ try:
     enclosure_uris = []
     for i in range(0, enclosure_count):
         enclosure_uris.append(enclosures[i]["uri"])
-    options["enclosureUris"] = enclosure_uris
+    options["enclosureUris"] = sorted(enclosure_uris)
 
     # Create a logical enclosure
     # This method is only available on HPE Synergy.

--- a/examples/logical_enclosures.py
+++ b/examples/logical_enclosures.py
@@ -45,8 +45,7 @@ try:
         enclosureUris=[],
         enclosureGroupUri="",
         forceInstallFirmware=False,
-        name="LogicalEnclosure2",
-        initialScopeUris=["/rest/scopes/cd237b60-09e2-45c4-829e-082e318a6d2a", "/rest/scopes/e9dde1f2-69d5-461b-871d-1790aebbc519"]
+        name="LogicalEnclosure2"
     )
 
     # Get enclosure group for creating logical enclosure
@@ -98,8 +97,8 @@ print("   Done.")
 # Get logical enclosure by id
 try:
     logical_enclosure_by_id = oneview_client.logical_enclosures.get(
-        "5a136d8e-d44a-42f9-bf28-5c93a93f8663")
-    print("Got logical enclosure '{}' by id: '5a136d8e-d44a-42f9-bf28-5c93a93f8663'\n   uri: '{}'".format(
+        "acb17b89-6724-4602-818a-1ee20ed4ec60")
+    print("Got logical enclosure '{}' by id: 'acb17b89-6724-4602-818a-1ee20ed4ec60'\n   uri: '{}'".format(
         logical_enclosure_by_id['name'], logical_enclosure_by_id['uri']))
 except HPOneViewException as e:
     print(e.msg)
@@ -185,7 +184,7 @@ if oneview_client.api_version >= 300:
             operation="replace",
             path="/firmware",
             value={
-                "firmwareBaselineUri": "/rest/firmware-drivers/spp-2017_04_0-SPP2017040_2017_0420_14",
+                "firmwareBaselineUri": "/rest/firmware-drivers/SPPgen9snap6_2016_0405_87",
                 "firmwareUpdateOn": "EnclosureOnly",
                 "forceInstallFirmware": "true",
                 "validateIfLIFirmwareUpdateIsNonDisruptive": "true",

--- a/examples/logical_enclosures.py
+++ b/examples/logical_enclosures.py
@@ -38,7 +38,6 @@ config = {
 config = try_load_from_file(config)
 
 oneview_client = OneViewClient(config)
-
 try:
     # The valid enclosure URIs need to be inserted sorted by URI
     # The number of enclosure URIs must be equal to the enclosure count in the enclosure group
@@ -46,7 +45,8 @@ try:
         enclosureUris=[],
         enclosureGroupUri="",
         forceInstallFirmware=False,
-        name="LogicalEnclosure2"
+        name="LogicalEnclosure2",
+        initialScopeUris=["/rest/scopes/cd237b60-09e2-45c4-829e-082e318a6d2a", "/rest/scopes/e9dde1f2-69d5-461b-871d-1790aebbc519"]
     )
 
     # Get enclosure group for creating logical enclosure
@@ -98,8 +98,8 @@ print("   Done.")
 # Get logical enclosure by id
 try:
     logical_enclosure_by_id = oneview_client.logical_enclosures.get(
-        "acb17b89-6724-4602-818a-1ee20ed4ec60")
-    print("Got logical enclosure '{}' by id: 'acb17b89-6724-4602-818a-1ee20ed4ec60'\n   uri: '{}'".format(
+        "5a136d8e-d44a-42f9-bf28-5c93a93f8663")
+    print("Got logical enclosure '{}' by id: '5a136d8e-d44a-42f9-bf28-5c93a93f8663'\n   uri: '{}'".format(
         logical_enclosure_by_id['name'], logical_enclosure_by_id['uri']))
 except HPOneViewException as e:
     print(e.msg)
@@ -117,6 +117,14 @@ try:
     print("Got logical enclosure by name '{name}'\n   uri: '{uri}'".format(**logical_enclosure_by_name))
 except HPOneViewException as e:
     print(e.msg)
+# Get Logical Enclosure by scope_uris
+if oneview_client.api_version == 600:
+    le_by_scope_uris = oneview_client.logical_enclosures.get_all(scope_uris="\"'/rest/scopes/cd237b60-09e2-45c4-829e-082e318a6d2a'\"")
+    if len(le_by_scope_uris) > 0:
+        print("Got Logical Enclosure by scope_uris: '%s'.\n  uri = '%s'" % (le_by_scope_uris[0]['name'], le_by_scope_uris[0]['uri']))
+        pprint(le_by_scope_uris)
+    else:
+        print("No Logical Enclosure found by scope_uris")
 
 # Update configuration
 print("Reapply the appliance's configuration to the logical enclosure")
@@ -177,7 +185,7 @@ if oneview_client.api_version >= 300:
             operation="replace",
             path="/firmware",
             value={
-                "firmwareBaselineUri": "/rest/firmware-drivers/SPPgen9snap6_2016_0405_87",
+                "firmwareBaselineUri": "/rest/firmware-drivers/spp-2017_04_0-SPP2017040_2017_0420_14",
                 "firmwareUpdateOn": "EnclosureOnly",
                 "forceInstallFirmware": "true",
                 "validateIfLIFirmwareUpdateIsNonDisruptive": "true",

--- a/hpOneView/resources/servers/logical_enclosures.py
+++ b/hpOneView/resources/servers/logical_enclosures.py
@@ -85,7 +85,7 @@ class LogicalEnclosures(object):
         """
         return self._client.delete(resource, force=force, timeout=timeout)
 
-    def get_all(self, start=0, count=-1, filter='', sort=''):
+    def get_all(self, start=0, count=-1, filter='', sort='', scope_uris=''):
         """
         Returns a list of logical enclosures matching the specified filter. A maximum of 40 logical enclosures are
         returned to the caller. Additional calls can be made to retrieve any other logical enclosures matching the
@@ -105,11 +105,14 @@ class LogicalEnclosures(object):
             sort:
                 The sort order of the returned data set. By default, the sort order is based
                 on create time with the oldest entry first.
+            scope_uris:
+                An expression to restrict the resources returned according to the scopes to
+                which they are assigned.
 
         Returns:
             list: A list of logical enclosures.
         """
-        return self._client.get_all(start, count, filter=filter, sort=sort)
+        return self._client.get_all(start, count, filter=filter, sort=sort, scope_uris=scope_uris)
 
     def get_by(self, field, value):
         """
@@ -182,8 +185,7 @@ class LogicalEnclosures(object):
         Returns:
             dict: Updated logical enclosure.
         """
-        headers = {'If-Match': '*'}
-        return self._client.patch(id_or_uri, operation, path, value, timeout=timeout, custom_headers=headers)
+        return self._client.patch(id_or_uri, operation, path, value, timeout=timeout)
 
     def update_configuration(self, id_or_uri, timeout=-1):
         """

--- a/tests/unit/resources/servers/test_logical_enclosures.py
+++ b/tests/unit/resources/servers/test_logical_enclosures.py
@@ -71,16 +71,17 @@ class LogicalEnclosuresTest(TestCase):
     def test_get_all_called_once(self, mock_get_all):
         filter = 'name=TestName'
         sort = 'name:ascending'
+        scope_uris = 'rest/scopes/cd237b60-09e2-45c4-829e-082e318a6d2a'
 
-        self._logical_enclosures.get_all(2, 500, filter, sort)
+        self._logical_enclosures.get_all(2, 500, filter, sort, scope_uris)
 
-        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort)
+        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort, scope_uris=scope_uris)
 
     @mock.patch.object(ResourceClient, 'get_all')
     def test_get_all_called_once_with_default_values(self, mock_get_all):
         self._logical_enclosures.get_all()
 
-        mock_get_all.assert_called_once_with(0, -1, filter='', sort='')
+        mock_get_all.assert_called_once_with(0, -1, filter='', sort='', scope_uris='')
 
     @mock.patch.object(ResourceClient, 'get_by')
     def test_get_by_called_once(self, mock_get_by):
@@ -130,7 +131,7 @@ class LogicalEnclosuresTest(TestCase):
         self._logical_enclosures.patch(
             '123a53cz', 'replace', '/name', 'new_name', 1)
         mock_patch.assert_called_once_with(
-            '123a53cz', 'replace', '/name', 'new_name', timeout=1, custom_headers={u'If-Match': u'*'})
+            '123a53cz', 'replace', '/name', 'new_name', timeout=1)
 
     @mock.patch.object(ResourceClient, 'update_with_zero_body')
     def test_update_configuration_by_uri(self, mock_update_with_zero_body):


### PR DESCRIPTION
Extending SDK support for OneView API version 600.

Resources;
Logical Enclosure

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [X] New endpoints supported are updated in the endpoints-support.md file.
- [X] Changes are documented in the CHANGELOG.
