### PR TITLE
api500 and api600 support for OS Build Plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Extends support of the SDK to OneView Rest API version 600 (OneView v4.0).
 - Logical switch
 - Logical switch group
 - Managed SAN
+- OS Build Plan
 - SAS interconnect type
 - SAS logical interconnect
 - SAS logical interconnect group

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -566,8 +566,8 @@
 
 ## HPE Synergy Image Streamer
 
-| Endpoints                                               | Verb    | V300               |
-| --------------------------------------------------------------------------------- | ------- | :----------------: |
+| Endpoints                                                                       | Verb     | V300 | V500 |V600
+| --------------------------------------------------------------------------------------- | -------- | :------------------: | :------------------: | :------------------: |
 |     **Artifacts Bundle**                                                                                         |
 |<sub>	/rest/artifact-bundles	</sub>                                                  | GET | :white_check_mark: |
 |<sub>	/rest/artifact-bundles	</sub>                                       |  POST(create)  | :white_check_mark: |
@@ -603,11 +603,11 @@
 |<sub> /rest/golden-images/{id}</sub>                                      | PUT              | :white_check_mark: |
 |<sub> /rest/golden-images/{id}</sub>                                      | DELETE           | :white_check_mark: |
 |     **OS Build Plan**                                                                                            |
-|<sub> /rest/build-plans</sub>                                             | POST             | :white_check_mark: |
-|<sub> /rest/build-plans</sub>                                             | GET              | :white_check_mark: |
-|<sub> /rest/build-plans/{id}</sub>                                        | GET              | :white_check_mark: |
-|<sub> /rest/build-plans/{id}</sub>                                        | PUT              | :white_check_mark: |
-|<sub> /rest/build-plans/{id}</sub>                                        | DELETE           | :white_check_mark: |
+|<sub> /rest/build-plans</sub>                                             | POST             | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub> /rest/build-plans</sub>                                             | GET              | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub> /rest/build-plans/{id}</sub>                                        | GET              | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub> /rest/build-plans/{id}</sub>                                        | PUT              | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub> /rest/build-plans/{id}</sub>                                        | DELETE           | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **OS Volumes**                                                                                               |
 |<sub> /rest/os-volumes</sub>                                              | GET              | :white_check_mark: |
 |<sub> /rest/os-volumes/{id}</sub>                                         | GET              | :white_check_mark: |
@@ -619,3 +619,4 @@
 |<sub> /rest/plan-scripts/{id}</sub>                                       | GET              | :white_check_mark: |
 |<sub> /rest/plan-scripts/{id}</sub>                                       | PUT              | :white_check_mark: |
 |<sub> /rest/plan-scripts/{id}</sub>                                       | DELETE           | :white_check_mark: |
+

--- a/hpOneView/image_streamer/resources/build_plans.py
+++ b/hpOneView/image_streamer/resources/build_plans.py
@@ -36,12 +36,15 @@ from hpOneView.resources.resource import ResourceClient
 class BuildPlans(object):
     URI = '/rest/build-plans'
 
+    DEFAULT_VALUES = {
+        '300': {'type': 'OeBuildPlan'},
+        '500': {'type': 'OeBuildPlanV5'},
+        '600': {'type': 'OeBuildPlanV5'}
+    }
+
     def __init__(self, con):
         self._connection = con
         self._client = ResourceClient(con, self.URI)
-        self.__default_values = {
-            'type': 'OeBuildPlan',
-        }
 
     def get_all(self, start=0, count=-1, filter='', sort=''):
         """
@@ -110,9 +113,7 @@ class BuildPlans(object):
             dict: Created OS Build Plan.
 
         """
-        data = self.__default_values.copy()
-        data.update(resource)
-        return self._client.create(data, timeout=timeout)
+        return self._client.create(resource, timeout=timeout, default_values=self.DEFAULT_VALUES)
 
     def update(self, resource, timeout=-1):
         """

--- a/tests/unit/image_streamer/resources/test_build_plans.py
+++ b/tests/unit/image_streamer/resources/test_build_plans.py
@@ -80,24 +80,17 @@ class BuildPlansTest(TestCase):
         mock_create.return_value = {}
 
         self._client.create(information)
-
-        expected_data = {
-            "type": "OeBuildPlan",
-            "name": "OS Build Plan Name",
-        }
-        mock_create.assert_called_once_with(expected_data, timeout=-1)
+        mock_create.assert_called_once_with(information, timeout=-1, default_values=self._client.DEFAULT_VALUES)
 
     @mock.patch.object(ResourceClient, 'create')
     def test_create_called_once_with_provided_type(self, mock_create):
         information = {
-            "type": "OeBuildPlan",
             "name": "OS Build Plan Name",
         }
-        expected_data = information.copy()
         mock_create.return_value = {}
 
         self._client.create(information)
-        mock_create.assert_called_once_with(expected_data, timeout=-1)
+        mock_create.assert_called_once_with(information, timeout=-1, default_values=self._client.DEFAULT_VALUES)
 
     @mock.patch.object(ResourceClient, 'update')
     def test_update_called_once(self, mock_update):


### PR DESCRIPTION
### Description
Support for api500 and 600 for Image streamer resource OS Build Plans

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [X] New endpoints supported are updated in the endpoints-support.md file.
- [X] Changes are documented in the CHANGELOG.
