### PR TITLE
Adding unit tests for get_reachable_storage_pools endpoint

### DIFF
--- a/tests/unit/resources/storage/test_storage_pools.py
+++ b/tests/unit/resources/storage/test_storage_pools.py
@@ -109,3 +109,10 @@ class StoragePoolsTest(unittest.TestCase):
         }
         self._storage_pools.update(storage_pool, 70)
         mock_update.assert_called_once_with(storage_pool, timeout=70)
+
+    @mock.patch.object(ResourceClient, 'get')
+    def test_get_reachable_storage_pools_called_once(self, mock_get):
+        reachable_pools_uri = "/rest/storage-pools/reachable-storage-pools?networks='/rest/fake'&start=0&count=-1"
+
+        self._storage_pools.get_reachable_storage_pools(networks=['/rest/fake'])
+        mock_get.assert_called_once_with(reachable_pools_uri)


### PR DESCRIPTION
### Description
Adding missing unit test for get_reachable_storage_pools endpoint to increase coverage

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [ ] Changes are documented in the CHANGELOG.
