### PR TITLE
Support for v600 for network sets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ Extends support of the SDK to OneView Rest API version 600 (OneView v4.0).
 
 #### Features supported with current release:
 - Deployment plan
-- Storage volume
+- Network set
 - Storage pool
+- Storage volume
 
 # 4.5.0
 #### Notes

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -312,14 +312,14 @@
 |<sub>/rest/migratable-vc-domains/{id}</sub>                                              | GET      | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/migratable-vc-domains/{id}</sub>                                              | DELETE   | :white_check_mark:   | :white_check_mark:   |
 |     **Network Sets**                                                                                                                              |
-|<sub>/rest/network-sets</sub>                                                            |GET       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/network-sets</sub>                                                            | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/network-sets/withoutEthernet</sub>                                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/network-sets/{id}</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/network-sets/{id}</sub>                                                       | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/network-sets/{id}</sub>                                                       | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/network-sets/{id}/withoutEthernet</sub>                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/network-sets/{id}</sub>                                                       | PATCH    | :heavy_minus_sign: | :white_check_mark: | :white_check_mark: |
+|<sub>/rest/network-sets</sub>                                                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/network-sets</sub>                                                            | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/network-sets/withoutEthernet</sub>                                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/network-sets/{id}</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/network-sets/{id}</sub>                                                       | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/network-sets/{id}</sub>                                                       | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/network-sets/{id}/withoutEthernet</sub>                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/network-sets/{id}</sub>                                                       | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :heavy_minus_sign:   |
 |     **OS Deployment Plans**                                                                                                                      |
 |<sub>/rest/os-deployment-plans/</sub>                                                    | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/os-deployment-plans/{id}</sub>                                                | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |

--- a/examples/network_sets.py
+++ b/examples/network_sets.py
@@ -112,7 +112,7 @@ print("Get all network sets without Ethernet")
 net_sets_without_ethernet = oneview_client.network_sets.get_all_without_ethernet()
 pprint(net_sets_without_ethernet)
 
-# Adds network set to scope defined
+# Adds network set to scope defined only for V300 and V500
 if scope_name:
     print("\nGet scope then add the network set to it")
     scope = oneview_client.scopes.get_by_name(scope_name)

--- a/examples/network_sets.py
+++ b/examples/network_sets.py
@@ -113,7 +113,7 @@ net_sets_without_ethernet = oneview_client.network_sets.get_all_without_ethernet
 pprint(net_sets_without_ethernet)
 
 # Adds network set to scope defined only for V300 and V500
-if scope_name:
+if scope_name and 300 <= oneview_client.api_version <= 500:
     print("\nGet scope then add the network set to it")
     scope = oneview_client.scopes.get_by_name(scope_name)
     net_set_with_scope = oneview_client.network_sets.patch(network_set['uri'],

--- a/hpOneView/resources/networking/network_sets.py
+++ b/hpOneView/resources/networking/network_sets.py
@@ -43,7 +43,8 @@ class NetworkSets(object):
     DEFAULT_VALUES = {
         '200': {"type": "network-set"},
         '300': {"type": "network-setV300"},
-        '500': {"type": "network-setV300"}
+        '500': {"type": "network-setV300"},
+        '600': {"type": "network-setV4"}
     }
 
     def __init__(self, con):


### PR DESCRIPTION
### Description
Support for Network sets for V600

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [X] New endpoints supported are updated in the endpoints-support.md file.
- [X] Changes are documented in the CHANGELOG.
