### PR TITLE
Fix bug in index_resources.get_all()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+#4.7.1(unreleased)
+#### Notes
+Bugfixes
+
+#### Bug fixes & Enhancements
+- [#364](https://github.com/HewlettPackard/python-hpOneView/issues/364) Bug in index_resources.get_all()
+
 # 4.7.0
 #### Notes
 Extends support of the SDK to OneView Rest API version 600 (OneView v4.0).

--- a/hpOneView/resources/search/index_resources.py
+++ b/hpOneView/resources/search/index_resources.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -88,25 +88,18 @@ class IndexResources(object):
         uri = self.URI + '?'
 
         uri += self.__list_or_str_to_query(category, 'category')
-        uri += self.__list_or_str_to_query(count, 'count')
         uri += self.__list_or_str_to_query(fields, 'fields')
         uri += self.__list_or_str_to_query(filter, 'filter')
         uri += self.__list_or_str_to_query(padding, 'padding')
         uri += self.__list_or_str_to_query(query, 'query')
         uri += self.__list_or_str_to_query(reference_uri, 'referenceUri')
         uri += self.__list_or_str_to_query(sort, 'sort')
-        uri += self.__list_or_str_to_query(start, 'start')
         uri += self.__list_or_str_to_query(user_query, 'userQuery')
         uri += self.__list_or_str_to_query(view, 'view')
 
         uri = uri.replace('?&', '?')
 
-        response = self._client.get(uri)
-
-        if response and 'members' in response and response['members']:
-            return response['members']
-        else:
-            return []
+        return self._client.get_all(start=start, count=count, uri=uri)
 
     def get(self, uri):
         """

--- a/tests/unit/resources/search/test_index_resources.py
+++ b/tests/unit/resources/search/test_index_resources.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2012-2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2012-2018) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -51,25 +51,24 @@ class IndexResourcesTest(unittest.TestCase):
         self.connection = connection(self.host)
         self._resource = IndexResources(self.connection)
 
-    @mock.patch.object(ResourceClient, 'get', return_value=dict(members='test'))
+    @mock.patch.object(ResourceClient, 'get_all', return_value=dict(members='test'))
     def test_get_all_called_once(self, mock_get_all):
         filter = 'name=TestName'
         sort = 'name:ascending'
 
-        expected_uri = '/rest/index/resources?count=500&filter=name=TestName&sort=name:ascending&start=2'
+        expected_uri = '/rest/index/resources?filter=name=TestName&sort=name:ascending'
 
         self._resource.get_all(start=2, count=500, filter=filter, sort=sort)
-        mock_get_all.assert_called_once_with(expected_uri)
+        mock_get_all.assert_called_once_with(start=2, count=500, uri=expected_uri)
 
-    @mock.patch.object(ResourceClient, 'get')
+    @mock.patch.object(ResourceClient, 'get_all')
     def test_get_all_called_once_without_results(self, mock_get_all):
         filter = 'name=TestName'
         sort = 'name:ascending'
 
-        expected_uri = '/rest/index/resources?count=500&filter=name=TestName&sort=name:ascending&start=2'
-
+        expected_uri = '/rest/index/resources?filter=name=TestName&sort=name:ascending'
         self._resource.get_all(start=2, count=500, filter=filter, sort=sort)
-        mock_get_all.assert_called_once_with(expected_uri)
+        mock_get_all.assert_called_once_with(start=2, count=500, uri=expected_uri)
 
     @mock.patch.object(ResourceClient, 'get')
     def test_get_called_once(self, mock_get):


### PR DESCRIPTION
### Description
The essential problem is that index_resources.get_all() calls the
Resource get() method which doesn't handle pagination and thus only
returns the first page of results. The complication is that
index_resources.get_all() builds its own URI complete with filtering, so
the Resource get_all() is probably not appropriate since it builds the
complete URI from a set of provided filters. To fix we've added a new
method to Resource - get_all_prebuilt_uri - which passes the pre-built
URI directly to the underlying __do_requests_to_getall method. The
implicated unit-tests have been updated.

### Issues Resolved
[ Fixes #364 ]

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [X] Changes are documented in the CHANGELOG.
