### PR TITLE
Firmware bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 4.7.1
+# 4.7.1 (Unreleased)
+#### Notes
+Extends support of the SDK to OneView Rest API version 600 (OneView v4.0).
+
+#### Features supported with current release:
+- Firmware Bundle
+
 #### Bug fixes
 - [#364] (https://github.com/HewlettPackard/python-hpOneView/issues/364) Bug in index_resources.get_all()
 

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -130,7 +130,7 @@
 |<sub>/rest/fcoe-networks/{id}</sub>                                                      | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
 |<sub>/rest/fcoe-networks/{id}</sub>                                                      | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
 |     **Firmware Bundles**                                                                                                                          |
-|<sub>/rest/firmware-bundles</sub>                                                       | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/firmware-bundles</sub>                                                       | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Firmware Drivers**                                                                                                                          |
 |<sub>/rest/firmware-drivers</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/firmware-drivers</sub>                                                       | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/examples/firmware_bundles.py
+++ b/examples/firmware_bundles.py
@@ -35,7 +35,10 @@ config = {
 }
 
 # To run this example you must define a path to a valid file
-firmware_path = "<path_to_firmware_bundle>"
+firmware_path = "/home/madhav/SPP2017072.2017_0921.4.iso"
+
+# Use the below option to specify additional request headers as required
+custom_headers = {'initialScopeUris': '/rest/scopes/bf3e77e3-3248-41b3-aaee-5d83b6ac4b49'}
 
 # Try load config from a file (if there is a config file)
 config = try_load_from_file(config)
@@ -43,6 +46,6 @@ oneview_client = OneViewClient(config)
 
 # Upload a firmware bundle
 print("\nUpload a firmware bundle")
-firmware_bundle_information = oneview_client.firmware_bundles.upload(file_path=firmware_path)
+firmware_bundle_information = oneview_client.firmware_bundles.upload(file_path=firmware_path, custom_headers=custom_headers)
 print("\n Upload successful! Firmware information returned: \n")
 pprint(firmware_bundle_information)

--- a/examples/firmware_bundles.py
+++ b/examples/firmware_bundles.py
@@ -35,10 +35,10 @@ config = {
 }
 
 # To run this example you must define a path to a valid file
-firmware_path = "/home/madhav/SPP2017072.2017_0921.4.iso"
+firmware_path = "<path_to_firmware_bundle>"
 
 # Use the below option to specify additional request headers as required
-custom_headers = {'initialScopeUris': '/rest/scopes/bf3e77e3-3248-41b3-aaee-5d83b6ac4b49'}
+custom_headers = {'initialScopeUris': '<Scope_Uris>'}
 
 # Try load config from a file (if there is a config file)
 config = try_load_from_file(config)
@@ -48,4 +48,4 @@ oneview_client = OneViewClient(config)
 print("\nUpload a firmware bundle")
 firmware_bundle_information = oneview_client.firmware_bundles.upload(file_path=firmware_path, custom_headers=custom_headers)
 print("\n Upload successful! Firmware information returned: \n")
-pprint(firmware_bundle_information)
+pprint(firmware_bundle_information['name'])

--- a/hpOneView/connection.py
+++ b/hpOneView/connection.py
@@ -271,8 +271,8 @@ class connection(object):
         fin.close()
         return content_type
 
-    def post_multipart_with_response_handling(self, uri, file_path, baseName):
-        resp, body = self.post_multipart(uri, None, file_path, baseName)
+    def post_multipart_with_response_handling(self, uri, file_path, custom_headers, baseName):
+        resp, body = self.post_multipart(uri, None, file_path, custom_headers, baseName)
 
         if resp.status == 202:
             task = self.__get_task_from_response(resp, body)
@@ -283,7 +283,7 @@ class connection(object):
 
         return None, body
 
-    def post_multipart(self, uri, fields, files, baseName, verbose=False):
+    def post_multipart(self, uri, fields, files, custom_headers, baseName, verbose=False):
         content_type = self.encode_multipart_formdata(fields, files, baseName,
                                                       verbose)
         inputfile = self._open(files + '.b64', 'rb')
@@ -295,6 +295,7 @@ class connection(object):
         conn.connect()
         conn.putrequest('POST', uri)
         conn.putheader('uploadfilename', baseName)
+        conn.putheader('initialScopeUris', custom_headers['initialScopeUris'])
         conn.putheader('auth', self._headers['auth'])
         conn.putheader('Content-Type', content_type)
         totalSize = os.path.getsize(files + '.b64')

--- a/hpOneView/connection.py
+++ b/hpOneView/connection.py
@@ -271,8 +271,8 @@ class connection(object):
         fin.close()
         return content_type
 
-    def post_multipart_with_response_handling(self, uri, file_path, custom_headers, baseName):
-        resp, body = self.post_multipart(uri, None, file_path, custom_headers, baseName)
+    def post_multipart_with_response_handling(self, uri, file_path, baseName, custom_headers):
+        resp, body = self.post_multipart(uri, None, file_path, baseName, custom_headers)
 
         if resp.status == 202:
             task = self.__get_task_from_response(resp, body)
@@ -283,7 +283,7 @@ class connection(object):
 
         return None, body
 
-    def post_multipart(self, uri, fields, files, custom_headers, baseName, verbose=False):
+    def post_multipart(self, uri, fields, files, baseName, custom_headers, verbose=False):
         content_type = self.encode_multipart_formdata(fields, files, baseName,
                                                       verbose)
         inputfile = self._open(files + '.b64', 'rb')

--- a/hpOneView/oneview_client.py
+++ b/hpOneView/oneview_client.py
@@ -905,9 +905,7 @@ class OneViewClient(object):
         Returns:
             FirmwareBundles:
         """
-        if not self.__firmware_bundles:
-            self.__firmware_bundles = FirmwareBundles(self.__connection)
-        return self.__firmware_bundles
+        return FirmwareBundles(self.__connection)
 
     @property
     def uplink_sets(self):

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -1209,7 +1209,7 @@ class ResourceClient(object):
 
         return self.__do_post(uri, resource, timeout, custom_headers)
 
-    def upload(self, file_path, uri=None, timeout=-1):
+    def upload(self, file_path, uri=None, custom_headers=None, timeout=-1):
         """
         Makes a multipart request.
 
@@ -1229,7 +1229,7 @@ class ResourceClient(object):
             uri = self._uri
 
         upload_file_name = os.path.basename(file_path)
-        task, entity = self._connection.post_multipart_with_response_handling(uri, file_path, upload_file_name)
+        task, entity = self._connection.post_multipart_with_response_handling(uri, file_path, custom_headers, upload_file_name)
 
         if not task:
             return entity

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -1209,7 +1209,7 @@ class ResourceClient(object):
 
         return self.__do_post(uri, resource, timeout, custom_headers)
 
-    def upload(self, file_path, uri=None, custom_headers=None, timeout=-1):
+    def upload(self, file_path, uri=None, timeout=-1, custom_headers=None):
         """
         Makes a multipart request.
 
@@ -1229,7 +1229,7 @@ class ResourceClient(object):
             uri = self._uri
 
         upload_file_name = os.path.basename(file_path)
-        task, entity = self._connection.post_multipart_with_response_handling(uri, file_path, custom_headers, upload_file_name)
+        task, entity = self._connection.post_multipart_with_response_handling(uri, file_path, upload_file_name, custom_headers)
 
         if not task:
             return entity

--- a/hpOneView/resources/settings/firmware_bundles.py
+++ b/hpOneView/resources/settings/firmware_bundles.py
@@ -45,7 +45,7 @@ class FirmwareBundles(object):
         self._connection = con
         self._client = ResourceClient(con, self.URI)
 
-    def upload(self, file_path, timeout=-1):
+    def upload(self, file_path, custom_headers=None, timeout=-1):
         """
         Upload an SPP ISO image file or a hotfix file to the appliance.
         The API supports upload of one hotfix at a time into the system.
@@ -59,4 +59,5 @@ class FirmwareBundles(object):
         Returns:
           dict: Information about the updated firmware bundle.
         """
-        return self._client.upload(file_path, timeout=timeout)
+#        custom_headers = { 'initialScopeUris': '/rest/scopes/bf3e77e3-3248-41b3-aaee-5d83b6ac4b49'}
+        return self._client.upload(file_path, custom_headers=custom_headers, timeout=timeout)

--- a/hpOneView/resources/settings/firmware_bundles.py
+++ b/hpOneView/resources/settings/firmware_bundles.py
@@ -45,7 +45,7 @@ class FirmwareBundles(object):
         self._connection = con
         self._client = ResourceClient(con, self.URI)
 
-    def upload(self, file_path, custom_headers=None, timeout=-1):
+    def upload(self, file_path, timeout=-1, custom_headers=None,):
         """
         Upload an SPP ISO image file or a hotfix file to the appliance.
         The API supports upload of one hotfix at a time into the system.
@@ -60,4 +60,4 @@ class FirmwareBundles(object):
           dict: Information about the updated firmware bundle.
         """
 #        custom_headers = { 'initialScopeUris': '/rest/scopes/bf3e77e3-3248-41b3-aaee-5d83b6ac4b49'}
-        return self._client.upload(file_path, custom_headers=custom_headers, timeout=timeout)
+        return self._client.upload(file_path, timeout=timeout, custom_headers=custom_headers)

--- a/tests/unit/resources/settings/test_firmware_bundles.py
+++ b/tests/unit/resources/settings/test_firmware_bundles.py
@@ -42,4 +42,4 @@ class FirmwareBundlesTest(unittest.TestCase):
 
         self._firmware_bundles.upload(firmware_path)
 
-        mock_upload.assert_called_once_with(firmware_path, timeout=-1)
+        mock_upload.assert_called_once_with(firmware_path, custom_headers=None, timeout=-1)

--- a/tests/unit/resources/settings/test_firmware_bundles.py
+++ b/tests/unit/resources/settings/test_firmware_bundles.py
@@ -42,4 +42,4 @@ class FirmwareBundlesTest(unittest.TestCase):
 
         self._firmware_bundles.upload(firmware_path)
 
-        mock_upload.assert_called_once_with(firmware_path, custom_headers=None, timeout=-1)
+        mock_upload.assert_called_once_with(firmware_path, timeout=-1, custom_headers=None)

--- a/tests/unit/resources/test_resource.py
+++ b/tests/unit/resources/test_resource.py
@@ -1217,7 +1217,7 @@ class ResourceClientTest(unittest.TestCase):
 
         self.resource_client.upload(filepath, uri)
 
-        mock_post_multipart.assert_called_once_with(uri, filepath, 'SPPgen9snap6.2015_0405.81.iso')
+        mock_post_multipart.assert_called_once_with(uri, filepath, None, 'SPPgen9snap6.2015_0405.81.iso')
 
     @mock.patch.object(connection, 'post_multipart_with_response_handling')
     def test_upload_should_call_post_multipart_with_resource_uri_when_not_uri_provided(self, mock_post_multipart):
@@ -1226,7 +1226,7 @@ class ResourceClientTest(unittest.TestCase):
 
         self.resource_client.upload(filepath)
 
-        mock_post_multipart.assert_called_once_with('/rest/testuri', mock.ANY, mock.ANY)
+        mock_post_multipart.assert_called_once_with('/rest/testuri', mock.ANY, mock.ANY, mock.ANY)
 
     @mock.patch.object(connection, 'post_multipart_with_response_handling')
     @mock.patch.object(TaskMonitor, 'wait_for_task')

--- a/tests/unit/resources/test_resource.py
+++ b/tests/unit/resources/test_resource.py
@@ -1217,7 +1217,7 @@ class ResourceClientTest(unittest.TestCase):
 
         self.resource_client.upload(filepath, uri)
 
-        mock_post_multipart.assert_called_once_with(uri, filepath, None, 'SPPgen9snap6.2015_0405.81.iso')
+        mock_post_multipart.assert_called_once_with(uri, filepath, 'SPPgen9snap6.2015_0405.81.iso', None)
 
     @mock.patch.object(connection, 'post_multipart_with_response_handling')
     def test_upload_should_call_post_multipart_with_resource_uri_when_not_uri_provided(self, mock_post_multipart):

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -629,6 +629,7 @@ class ConnectionTest(unittest.TestCase):
         self.connection.post_multipart(uri='/rest/resources/',
                                        fields=None,
                                        files="/a/path/filename.zip",
+                                       custom_headers={'initialScopeUris': '/rest/scopes/fake'},
                                        baseName="archive.zip")
 
         internal_conn = self.connection.get_connection.return_value
@@ -646,10 +647,12 @@ class ConnectionTest(unittest.TestCase):
         self.connection.post_multipart(uri='/rest/resources/',
                                        fields=None,
                                        files="/a/path/filename.zip",
+                                       custom_headers={'initialScopeUris': '/rest/scopes/fake'},
                                        baseName="archive.zip")
 
         expected_putheader_calls = [
             call('uploadfilename', 'archive.zip'),
+            call(u'initialScopeUris', '/rest/scopes/fake'),
             call('auth', 'LTIxNjUzMjc0OTUzzHoF7eEkZLEUWVA-fuOZP4VGA3U8e67E'),
             call('Content-Type', 'multipart/form-data; boundary=----------ThIs_Is_tHe_bouNdaRY_$'),
             call('Content-Length', 2621440),
@@ -669,6 +672,7 @@ class ConnectionTest(unittest.TestCase):
         self.connection.post_multipart(uri='/rest/resources/',
                                        fields=None,
                                        files="/a/path/filename.zip",
+                                       custom_headers={'initialScopeUris': '/rest/scopes/fake'},
                                        baseName="archive.zip")
 
         expected_mmap_read_calls = [
@@ -689,6 +693,7 @@ class ConnectionTest(unittest.TestCase):
         self.connection.post_multipart(uri='/rest/resources/',
                                        fields=None,
                                        files="/a/path/filename.zip",
+                                       custom_headers={'initialScopeUris': '/rest/scopes/fake'},
                                        baseName="archive.zip")
 
         expected_conn_send_calls = [
@@ -710,6 +715,7 @@ class ConnectionTest(unittest.TestCase):
         self.connection.post_multipart(uri='/rest/resources/',
                                        fields=None,
                                        files="/a/path/filename.zip",
+                                       custom_headers={'initialScopeUris': '/rest/scopes/fake'},
                                        baseName="archive.zip")
 
         mock_rm.assert_called_once_with('/a/path/filename.zip.b64')
@@ -727,6 +733,7 @@ class ConnectionTest(unittest.TestCase):
             self.connection.post_multipart(uri='/rest/resources/',
                                            fields=None,
                                            files="/a/path/filename.zip",
+                                           custom_headers={'initialScopeUris': '/rest/scopes/fake'},
                                            baseName="archive.zip")
         except HPOneViewException as e:
             self.assertEqual(e.msg, "An error occurred.")
@@ -745,6 +752,7 @@ class ConnectionTest(unittest.TestCase):
         response, body = self.connection.post_multipart(uri='/rest/resources/',
                                                         fields=None,
                                                         files="/a/path/filename.zip",
+                                                        custom_headers={'initialScopeUris': '/rest/scopes/fake'},
                                                         baseName="archive.zip")
 
         self.assertEqual(body, self.expected_response_body)
@@ -764,6 +772,7 @@ class ConnectionTest(unittest.TestCase):
         response, body = self.connection.post_multipart(uri='/rest/resources/',
                                                         fields=None,
                                                         files="/a/path/filename.zip",
+                                                        custom_headers={'initialScopeUris': '/rest/scopes/fake'},
                                                         baseName="archive.zip")
 
         self.assertTrue(body)
@@ -775,7 +784,7 @@ class ConnectionTest(unittest.TestCase):
         mock_response.getheader.return_value = None
         mock_post_multipart.return_value = mock_response, "content"
 
-        task, body = self.connection.post_multipart_with_response_handling("uri", "filepath", "basename")
+        task, body = self.connection.post_multipart_with_response_handling("uri", "filepath", "custom_headers", "basename")
 
         self.assertFalse(task)
         self.assertEqual(body, "content")
@@ -789,7 +798,7 @@ class ConnectionTest(unittest.TestCase):
         mock_post_multipart.return_value = mock_response, "content"
         mock_get.return_value = fake_task
 
-        task, body = self.connection.post_multipart_with_response_handling("uri", "filepath", "basename")
+        task, body = self.connection.post_multipart_with_response_handling("uri", "filepath", "custom_headers", "basename")
 
         self.assertEqual(task, fake_task)
         self.assertEqual(body, "content")
@@ -799,7 +808,7 @@ class ConnectionTest(unittest.TestCase):
         fake_task = {"category": "tasks"}
         mock_post_multipart.return_value = Mock(status=200), fake_task
 
-        task, body = self.connection.post_multipart_with_response_handling("uri", "filepath", "basename")
+        task, body = self.connection.post_multipart_with_response_handling("uri", "filepath", "custom_headers", "basename")
 
         self.assertEqual(task, fake_task)
         self.assertEqual(body, fake_task)
@@ -808,7 +817,7 @@ class ConnectionTest(unittest.TestCase):
     def test_post_multipart_with_response_handling_when_status_200_and_body_is_not_task(self, mock_post_multipart):
         mock_post_multipart.return_value = Mock(status=200), "content"
 
-        task, body = self.connection.post_multipart_with_response_handling("uri", "filepath", "basename")
+        task, body = self.connection.post_multipart_with_response_handling("uri", "filepath", "custom_headers", "basename")
 
         self.assertFalse(task)
         self.assertEqual(body, "content")

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -79,6 +79,7 @@ from hpOneView.resources.security.users import Users
 from hpOneView.resources.settings.appliance_node_information import ApplianceNodeInformation
 from hpOneView.resources.settings.appliance_time_and_locale_configuration import ApplianceTimeAndLocaleConfiguration
 from hpOneView.resources.settings.versions import Versions
+from hpOneView.resources.settings.firmware_bundles import FirmwareBundles
 from tests.test_utils import mock_builtin
 from hpOneView.resources.settings.licenses import Licenses
 
@@ -566,9 +567,11 @@ class OneViewClientTest(unittest.TestCase):
         firmware_drivers = self._oneview.firmware_drivers
         self.assertEqual(firmware_drivers, self._oneview.firmware_drivers)
 
-    def test_lazy_loading_firmware_bundles(self):
-        firmware_bundles = self._oneview.firmware_bundles
-        self.assertEqual(firmware_bundles, self._oneview.firmware_bundles)
+    def test_firmware_bundles_has_right_type(self):
+        self.assertIsInstance(self._oneview.firmware_bundles, FirmwareBundles)
+
+    def test_firmware_bundles_has_value(self):
+        self.assertIsNotNone(self._oneview.firmware_bundles)
 
     def test_migratable_vc_domains_has_right_type(self):
         self.assertIsInstance(self._oneview.migratable_vc_domains, MigratableVcDomains)


### PR DESCRIPTION
### Description
Adds additional custom headers' support for firmware bundles introduced in api600.

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [X] New endpoints supported are updated in the endpoints-support.md file.
- [X] Changes are documented in the CHANGELOG.
