### PR TITLE
Upgrade/800/ethernet networks and uplink sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,12 @@ Resource data will be available with the resource object. This enhancement helps
 - Connection template
 - Enclosure
 - Enclosure group
+- Ethernet network
 - FC network
 - FCOE network
 - Interconnect type
 - Server hardware type
+- Uplink set
 
 # 4.8.0
 #### Notes

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -121,15 +121,15 @@
 |<sub>/rest/fc-sans/endpoints</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/fc-sans/endpoints/{id}</sub>                                                  | GET      |  :heavy_minus_sign:  | :heavy_multiplication_x: | :heavy_multiplication_x:
 |     **Ethernet Networks**                                                                                                                         |
-|<sub>/rest/ethernet-networks</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks</sub>                                                       | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/bulk</sub>                                                  | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/{id}</sub>                                                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/{id}</sub>                                                  | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/{id}</sub>                                                  | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :heavy_minus_sign:   |
-|<sub>/rest/ethernet-networks/{id}</sub>                                                  | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/{id}/associatedProfiles</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/{id}/associatedUplinkGroups</sub>                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks</sub>                                                       | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/bulk</sub>                                                  | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/{id}</sub>                                                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/{id}</sub>                                                  | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/{id}</sub>                                                  | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/ethernet-networks/{id}</sub>                                                  | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/{id}/associatedProfiles</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/{id}/associatedUplinkGroups</sub>                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Events**                                                                                                                         |
 |<sub>/rest/events</sub>                                                                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/events</sub>                                                                  | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
@@ -547,11 +547,11 @@
 |<sub>/rest/unmanaged-devices/{id}</sub>                                                  | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/unmanaged-devices/{id}/environmentalConfiguration</sub>                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Uplink Sets**                                                                                                                              |
-|<sub>/rest/uplink-sets</sub>                                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/uplink-sets</sub>                                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/uplink-sets/{id}</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/uplink-sets/{id}</sub>                                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/uplink-sets/{id}</sub>                                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/uplink-sets</sub>                                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/uplink-sets</sub>                                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/uplink-sets/{id}</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/uplink-sets/{id}</sub>                                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/uplink-sets/{id}</sub>                                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Users**                                                                                                                                   |
 |<sub>/rest/users</sub>                                                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/users</sub>                                                                   | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/examples/ethernet_networks.py
+++ b/examples/ethernet_networks.py
@@ -58,101 +58,102 @@ options_bulk = {
 
 # Scope name to perform the patch operation
 scope_name = ""
+ethernet_name = ""
 
 # Try load config from a file (if there is a config file)
 config = try_load_from_file(config)
 
 oneview_client = OneViewClient(config)
-
-# Create an ethernet Network
-print("\nCreate an ethernet network")
-ethernet_network = oneview_client.ethernet_networks.create(options)
-print("Created ethernet-network '{name}' successfully.\n   uri = '{uri}'" .format(**ethernet_network))
-
-# Find recently created network by name
-print("\nFind recently created network by name")
-ethernet_network = oneview_client.ethernet_networks.get_by(
-    'name', 'OneViewSDK Test Ethernet Network')[0]
-print("Found ethernet-network by name: '{name}'.\n   uri = '{uri}'" .format(**ethernet_network))
-
-# Update purpose recently created network
-print("\nUpdate the purpose attribute from the recently created network")
-ethernet_network['purpose'] = 'Management'
-ethernet_network = oneview_client.ethernet_networks.update(ethernet_network)
-print("Updated ethernet-network '{name}' successfully.\n   uri = '{uri}'\n   with attribute ['purpose': {purpose}]"
-      .format(**ethernet_network))
+ethernet_networks = oneview_client.ethernet_networks
 
 # Get all, with defaults
 print("\nGet all ethernet-networks")
-ethernet_nets = oneview_client.ethernet_networks.get_all()
+ethernet_nets = ethernet_networks.get_all()
 for net in ethernet_nets:
     print("   '{name}' at uri: '{uri}'".format(**net))
 
-# Create bulk ethernet networks
-print("\nCreate bulk ethernet networks")
-ethernet_nets_bulk = oneview_client.ethernet_networks.create_bulk(options_bulk)
-pprint(ethernet_nets_bulk)
+# Get by Uri
+print("\nGet an ethernet-network by uri")
+ethernet_network_uri = ethernet_nets[0]['uri']
+ethernet_nets_by_uri = ethernet_networks.get_by_uri(ethernet_network_uri)
+pprint(ethernet_nets_by_uri.data)
 
 # Filter by name
 print("\nGet all ethernet-networks filtering by name")
-ethernet_nets_filtered = oneview_client.ethernet_networks.get_all(
+ethernet_nets_filtered = ethernet_networks.get_all(
     filter="\"'name'='OneViewSDK Test Ethernet Network'\"")
 for net in ethernet_nets_filtered:
     print("   '{name}' at uri: '{uri}'".format(**net))
 
 # Get all sorting by name descending
 print("\nGet all ethernet-networks sorting by name")
-ethernet_nets_sorted = oneview_client.ethernet_networks.get_all(sort='name:descending')
+ethernet_nets_sorted = ethernet_networks.get_all(sort='name:descending')
 for net in ethernet_nets_sorted:
     print("   '{name}' at uri: '{uri}'".format(**net))
 
 # Get the first 10 records
 print("\nGet the first ten ethernet-networks")
-ethernet_nets_limited = oneview_client.ethernet_networks.get_all(0, 10)
+ethernet_nets_limited = ethernet_networks.get_all(0, 10)
 for net in ethernet_nets_limited:
     print("   '{name}' at uri: '{uri}'".format(**net))
 
-ethernet_network_uri = ethernet_network['uri']
+# Create bulk ethernet networks
+print("\nCreate bulk ethernet networks")
+ethernet_nets_bulk = ethernet_networks.create_bulk(options_bulk)
+pprint(ethernet_nets_bulk)
 
-# Get by Uri
-print("\nGet an ethernet-network by uri")
-ethernet_nets_by_uri = oneview_client.ethernet_networks.get(ethernet_network_uri)
-pprint(ethernet_nets_by_uri)
+# Find network by name
+print("\nFind recently created network by name")
+ethernet_network = oneview_client.ethernet_networks.get_by_name(ethernet_name)
+print("Found ethernet-network by name: '{name}'.\n   uri = '{uri}'" .format(**ethernet_network.data))
+if not ethernet_network:
+    # Create an ethernet Network
+    print("\nCreate an ethernet network")
+    ethernet_network = oneview_client.ethernet_networks.create(options)
+    print("Created ethernet-network '{name}' successfully.\n   uri = '{uri}'" .format(**ethernet_network.data))
+
+# Update purpose recently created network
+print("\nUpdate the purpose attribute from the recently created network")
+ethernet_data = ethernet_network.data
+ethernet_data['purpose'] = 'Management'
+ethernet_network = ethernet_network.update(ethernet_data)
+print("Updated ethernet-network '{name}' successfully.\n   uri = '{uri}'\n   with attribute ['purpose': {purpose}]"
+      .format(**ethernet_network))
 
 # Get URIs of associated profiles
 print("\nGet associated profiles uri(s)")
-associated_profiles = oneview_client.ethernet_networks.get_associated_profiles(ethernet_network_uri)
+associated_profiles = ethernet_network.get_associated_profiles()
 pprint(associated_profiles)
 
 # Get URIs of uplink port group
 print("\nGet uplink port group uri(s)")
-uplink_group_uris = oneview_client.ethernet_networks.get_associated_uplink_groups(ethernet_network_uri)
+uplink_group_uris = ethernet_network.get_associated_uplink_groups()
 pprint(uplink_group_uris)
 
+#TODO:: Update when uplink module is upadated with base class changes
 # Get the associated uplink set resources
-print("\nGet uplink port group uri(s)")
-uplink_groups = []
-for uri in uplink_group_uris:
-    uplink_groups.append(oneview_client.uplink_sets.get(uri))
-pprint(uplink_groups)
+#print("\nGet uplink port group uri(s)")
+#uplink_groups = []
+#for uri in uplink_group_uris:
+#    uplink_groups.append(oneview_client.uplink_sets.get(uri))
+#pprint(uplink_groups)
 
 # Adds ethernet to scope defined
 if scope_name:
     print("\nGet scope then add the network to it")
     scope = oneview_client.scopes.get_by_name(scope_name)
-    ethernet_with_scope = oneview_client.ethernet_networks.patch(ethernet_network_uri,
-                                                                 'replace',
-                                                                 '/scopeUris',
-                                                                 [scope['uri']])
+    ethernet_with_scope = ethernet_network.patch('replace',
+                                                 '/scopeUris',
+                                                 [scope['uri']])
     pprint(ethernet_with_scope)
 
 # Delete bulk ethernet networks
 print("\nDelete bulk ethernet networks")
 for net in ethernet_nets_bulk:
-    oneview_client.ethernet_networks.delete(net)
+    ethernet_networks.get_by_uri(net['uri']).delete()
 print("   Done.")
 
 # Delete the created network
 print("\nDelete the ethernet network")
-oneview_client.ethernet_networks.delete(ethernet_network)
+ethernet_network.delete()
 print("Successfully deleted ethernet-network")

--- a/examples/ethernet_networks.py
+++ b/examples/ethernet_networks.py
@@ -27,10 +27,10 @@ from config_loader import try_load_from_file
 from hpOneView.oneview_client import OneViewClient
 
 config = {
-    "ip": "<oneview_ip>",
+    "ip": "10.30.5.74",
     "credentials": {
-        "userName": "<username>",
-        "password": "<password>"
+        "userName": "administrator",
+        "password": "sijenov@2017"
     }
 }
 
@@ -58,7 +58,7 @@ options_bulk = {
 
 # Scope name to perform the patch operation
 scope_name = ""
-ethernet_name = ""
+ethernet_name = "OneViewSDK Test Ethernet Network"
 
 # Try load config from a file (if there is a config file)
 config = try_load_from_file(config)
@@ -97,20 +97,21 @@ ethernet_nets_limited = ethernet_networks.get_all(0, 10)
 for net in ethernet_nets_limited:
     print("   '{name}' at uri: '{uri}'".format(**net))
 
-# Create bulk ethernet networks
-print("\nCreate bulk ethernet networks")
-ethernet_nets_bulk = ethernet_networks.create_bulk(options_bulk)
-pprint(ethernet_nets_bulk)
-
 # Find network by name
-print("\nFind recently created network by name")
+print("\nFind network by name")
 ethernet_network = oneview_client.ethernet_networks.get_by_name(ethernet_name)
-print("Found ethernet-network by name: '{name}'.\n   uri = '{uri}'" .format(**ethernet_network.data))
-if not ethernet_network:
+if ethernet_network:
+    print("Found ethernet-network by name: '{name}'.\n   uri = '{uri}'" .format(**ethernet_network.data))
+else:
     # Create an ethernet Network
     print("\nCreate an ethernet network")
     ethernet_network = oneview_client.ethernet_networks.create(options)
     print("Created ethernet-network '{name}' successfully.\n   uri = '{uri}'" .format(**ethernet_network.data))
+
+# Create bulk ethernet networks
+print("\nCreate bulk ethernet networks")
+ethernet_nets_bulk = ethernet_networks.create_bulk(options_bulk)
+pprint(ethernet_nets_bulk)
 
 # Update purpose recently created network
 print("\nUpdate the purpose attribute from the recently created network")
@@ -118,7 +119,7 @@ ethernet_data = ethernet_network.data
 ethernet_data['purpose'] = 'Management'
 ethernet_network = ethernet_network.update(ethernet_data)
 print("Updated ethernet-network '{name}' successfully.\n   uri = '{uri}'\n   with attribute ['purpose': {purpose}]"
-      .format(**ethernet_network))
+      .format(**ethernet_network.data))
 
 # Get URIs of associated profiles
 print("\nGet associated profiles uri(s)")

--- a/examples/ethernet_networks.py
+++ b/examples/ethernet_networks.py
@@ -27,7 +27,7 @@ from config_loader import try_load_from_file
 from hpOneView.oneview_client import OneViewClient
 
 config = {
-    "ip": "oneview_ip",
+    "ip": "<oneview_ip>",
     "credentials": {
         "userName": "<username>",
         "password": "<password>"

--- a/examples/ethernet_networks.py
+++ b/examples/ethernet_networks.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2012-2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2012-2019) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,11 +27,12 @@ from config_loader import try_load_from_file
 from hpOneView.oneview_client import OneViewClient
 
 config = {
-    "ip": "10.30.5.74",
+    "ip": "oneview_ip",
     "credentials": {
-        "userName": "administrator",
-        "password": "sijenov@2017"
-    }
+        "userName": "<username>",
+        "password": "<password>"
+    },
+    "api_version": 800
 }
 
 options = {
@@ -131,13 +132,12 @@ print("\nGet uplink port group uri(s)")
 uplink_group_uris = ethernet_network.get_associated_uplink_groups()
 pprint(uplink_group_uris)
 
-#TODO:: Update when uplink module is upadated with base class changes
 # Get the associated uplink set resources
-#print("\nGet uplink port group uri(s)")
-#uplink_groups = []
-#for uri in uplink_group_uris:
-#    uplink_groups.append(oneview_client.uplink_sets.get(uri))
-#pprint(uplink_groups)
+print("\nGet associated uplink sets")
+uplink_sets = oneview_client.uplink_sets
+for uri in uplink_group_uris:
+    uplink = uplink_sets.get_by_uri(uri)
+    pprint(uplink.data)
 
 # Adds ethernet to scope defined
 if scope_name:

--- a/examples/uplink_sets.py
+++ b/examples/uplink_sets.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2012-2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2012-2019) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,34 +28,42 @@ from hpOneView.oneview_client import OneViewClient
 
 # To run this example fill the ip and the credentials bellow or use a configuration file
 config = {
-    "ip": "10.30.5.74",
+    "ip": "<oneview_ip>",
     "credentials": {
-        "userName": "administrator",
-        "password": "sijenov@2017",
-    }
+        "userName": "<username>",
+        "password": "<password>",
+    },
+    "api_version": 800
 }
 
 # Try load config from a file (if there is a config file)
 config = try_load_from_file(config)
+
 oneview_client = OneViewClient(config)
 uplink_sets = oneview_client.uplink_sets
 
 
-# To run this example you can define an logical interconnect uri (logicalInterconnectUri) and the ethernet network uri
-# or the example will attempt to retrieve those automatically from the appliance.
+# To run this example you can define an logical interconnect uri (logicalInterconnectUri), ethernet network uri
+# and ethernet name or the example will attempt to retrieve those automatically from the appliance.
 logical_interconnect_uri = None
 ethernet_network_uri = None
+ethernet_network_name = None
 
 # Attempting to get first LI and Ethernet uri and use them for this example
-#if logical_interconnect_uri is None:
-#    logical_interconnect_uri = oneview_client.logical_interconnects.get_all()[0]['uri']
+if logical_interconnect_uri is None:
+    logical_interconnect_uri = oneview_client.logical_interconnects.get_all()[0]['uri']
 if ethernet_network_uri is None:
-    ethernet_network_uri = oneview_client.ethernet_networks.get_all()[0]['uri']
+    enet = oneview_client.ethernet_networks.get_all()
+    ethernet_network_uri = enet[0]['uri']
+
+    # Ethernet name to test add/remove of network uris
+    if not ethernet_network_name:
+        ethernet_network_name = enet[1]['name']
 
 options = {
     "name": "Uplink Set Demo",
     "status": "OK",
-#    "logicalInterconnectUri": logical_interconnect_uri,
+    "logicalInterconnectUri": logical_interconnect_uri,
     "networkUris": [
         ethernet_network_uri
     ],
@@ -73,52 +81,50 @@ all_uplink_sets = uplink_sets.get_all(0, 15, sort='name:ascending')
 for uplink_set in all_uplink_sets:
     print('  %s' % uplink_set['name'])
 
-# Get an uplink set resource by name
 if all_uplink_sets:
-    print("\nGet uplink set by name")
-    uplink_name = all_uplink_sets[0]['name']
-    uplink_set = uplink_sets.get_by('name', uplink_name)[0]
-    print("Found uplink set at uri '{uri}'\n  by name = '{name}'".format(**uplink_set))
-
     # Get an uplink set resource by uri
     print("\nGet an uplink set by uri")
     uplink_uri = all_uplink_sets[0]['uri']
     uplink_set = uplink_sets.get_by_uri(uplink_uri)
     pprint(uplink_set.data)
 
-# Create an uplink set
-print("\nCreate an uplink set")
-created_uplink_set = uplink_sets.create(options)
-print("Created uplink set '{name}' successfully.\n  uri = '{uri}'".format(**created_uplink_set.data))
+# Get an uplink set resource by name
+print("\nGet uplink set by name")
+uplink_set = uplink_sets.get_by_name(options["name"])
+if uplink_set:
+    print("Found uplink set at uri '{uri}'\n  by name = '{name}'".format(**uplink_set.data))
+else:
+    # Create an uplink set
+    print("\nCreate an uplink set")
+    uplink_set = uplink_sets.create(options)
+    print("Created uplink set '{name}' successfully.\n  uri = '{uri}'".format(**uplink_set.data))
 
 # Update an uplink set
 print("\nUpdate an uplink set")
-created_uplink_set.data['name'] = 'Renamed Uplink Set Demo'
-updated_uplink_set = created_uplink_set.update(created_uplink_set.data)
-print("Updated uplink set name to '{name}' successfully.\n  uri = '{uri}'".format(**updated_uplink_set.data))
-
+uplink_set.data['name'] = 'Renamed Uplink Set Demo'
+uplink_set.update(uplink_set.data)
+print("Updated uplink set name to '{name}' successfully.\n  uri = '{uri}'".format(**uplink_set.data))
 
 # Add an ethernet network to the uplink set
 # To run this example you must define an ethernet network uri or ID below
-if ethernet_network_uri:
+if ethernet_network_name:
     print("\nAdd an ethernet network to the uplink set")
-    uplink_set = created_uplink_set.add_ethernet_networks(ethernet_network_uri)
-    print("The uplink set with name = '{name}' have now the networkUris:\n {networkUris}".format(**uplink_set))
-
+    uplink_added_ethernet = uplink_set.add_ethernet_networks(ethernet_network_name)
+    print("The uplink set with name = '{name}' have now the networkUris:\n {networkUris}".format(**uplink_added_ethernet))
 
 # Remove an ethernet network from the uplink set
 # To run this example you must define an ethernet network uri or ID below
-if ethernet_network_uri:
+if ethernet_network_name:
     print("\nRemove an ethernet network of the uplink set")
-    uplink_set = created_uplink_set.remove_ethernet_networks(ethernet_network_uri)
-    print("The uplink set with name = '{name}' have now the networkUris:\n {networkUris}".format(**uplink_set))
+    uplink_removed_ethernet = uplink_set.remove_ethernet_networks(ethernet_network_name)
+    print("The uplink set with name = '{name}' have now the networkUris:\n {networkUris}".format(**uplink_removed_ethernet))
 
 # Get the associated ethernet networks of an uplink set
 print("\nGet the associated ethernet networks of the uplink set")
-networks = created_uplink_set.get_ethernet_networks()
+networks = uplink_set.get_ethernet_networks()
 pprint(networks)
 
 # Delete the recently created uplink set
 print("\nDelete the uplink set")
-created_with_uplink_set.delete()
+uplink_set.delete()
 print("Successfully deleted the uplink set")

--- a/examples/uplink_sets.py
+++ b/examples/uplink_sets.py
@@ -28,17 +28,18 @@ from hpOneView.oneview_client import OneViewClient
 
 # To run this example fill the ip and the credentials bellow or use a configuration file
 config = {
-    "ip": "<oneview_ip>",
+    "ip": "10.30.5.74",
     "credentials": {
-        "userName": "<oneview_administrator_name>",
-        "password": "<oneview_administrator_password>",
+        "userName": "administrator",
+        "password": "sijenov@2017",
     }
 }
 
 # Try load config from a file (if there is a config file)
 config = try_load_from_file(config)
-
 oneview_client = OneViewClient(config)
+uplink_sets = oneview_client.uplink_sets
+
 
 # To run this example you can define an logical interconnect uri (logicalInterconnectUri) and the ethernet network uri
 # or the example will attempt to retrieve those automatically from the appliance.
@@ -46,15 +47,15 @@ logical_interconnect_uri = None
 ethernet_network_uri = None
 
 # Attempting to get first LI and Ethernet uri and use them for this example
-if logical_interconnect_uri is None:
-    logical_interconnect_uri = oneview_client.logical_interconnects.get_all()[0]['uri']
+#if logical_interconnect_uri is None:
+#    logical_interconnect_uri = oneview_client.logical_interconnects.get_all()[0]['uri']
 if ethernet_network_uri is None:
     ethernet_network_uri = oneview_client.ethernet_networks.get_all()[0]['uri']
 
 options = {
     "name": "Uplink Set Demo",
     "status": "OK",
-    "logicalInterconnectUri": logical_interconnect_uri,
+#    "logicalInterconnectUri": logical_interconnect_uri,
     "networkUris": [
         ethernet_network_uri
     ],
@@ -66,55 +67,58 @@ options = {
     "manualLoginRedistributionState": "NotSupported",
 }
 
-# Create an uplink set
-print("\nCreate an uplink set")
-created_uplink_set = oneview_client.uplink_sets.create(options)
-print("Created uplink set '{name}' successfully.\n  uri = '{uri}'".format(**created_uplink_set))
-
-# Update an uplink set
-print("\nUpdate an uplink set")
-created_uplink_set['name'] = 'Renamed Uplink Set Demo'
-updated_uplink_set = oneview_client.uplink_sets.update(created_uplink_set)
-print("Updated uplink set name to '{name}' successfully.\n  uri = '{uri}'".format(**updated_uplink_set))
-
 # Get a paginated list of uplink set resources sorting by name ascending and filtering by status
 print("\nGet a list of uplink sets")
-uplink_sets = oneview_client.uplink_sets.get_all(0, 15, sort='name:ascending')
-for uplink_set in uplink_sets:
+all_uplink_sets = uplink_sets.get_all(0, 15, sort='name:ascending')
+for uplink_set in all_uplink_sets:
     print('  %s' % uplink_set['name'])
 
 # Get an uplink set resource by name
-print("\nGet uplink set by name")
-uplink_set = oneview_client.uplink_sets.get_by('name', 'Renamed Uplink Set Demo')[0]
-print("Found uplink set at uri '{uri}'\n  by name = '{name}'".format(**uplink_set))
+if all_uplink_sets:
+    print("\nGet uplink set by name")
+    uplink_name = all_uplink_sets[0]['name']
+    uplink_set = uplink_sets.get_by('name', uplink_name)[0]
+    print("Found uplink set at uri '{uri}'\n  by name = '{name}'".format(**uplink_set))
+
+    # Get an uplink set resource by uri
+    print("\nGet an uplink set by uri")
+    uplink_uri = all_uplink_sets[0]['uri']
+    uplink_set = uplink_sets.get_by_uri(uplink_uri)
+    pprint(uplink_set.data)
+
+# Create an uplink set
+print("\nCreate an uplink set")
+created_uplink_set = uplink_sets.create(options)
+print("Created uplink set '{name}' successfully.\n  uri = '{uri}'".format(**created_uplink_set.data))
+
+# Update an uplink set
+print("\nUpdate an uplink set")
+created_uplink_set.data['name'] = 'Renamed Uplink Set Demo'
+updated_uplink_set = created_uplink_set.update(created_uplink_set.data)
+print("Updated uplink set name to '{name}' successfully.\n  uri = '{uri}'".format(**updated_uplink_set.data))
+
 
 # Add an ethernet network to the uplink set
 # To run this example you must define an ethernet network uri or ID below
-ethernet_network_id = None
-if ethernet_network_id:
+if ethernet_network_uri:
     print("\nAdd an ethernet network to the uplink set")
-    uplink_set = oneview_client.uplink_sets.add_ethernet_networks(created_uplink_set['uri'], ethernet_network_id)
+    uplink_set = created_uplink_set.add_ethernet_networks(ethernet_network_uri)
     print("The uplink set with name = '{name}' have now the networkUris:\n {networkUris}".format(**uplink_set))
 
-# Get an uplink set resource by uri
-print("\nGet an uplink set by uri")
-uplink_set = oneview_client.uplink_sets.get(created_uplink_set['uri'])
-pprint(uplink_set)
 
 # Remove an ethernet network from the uplink set
 # To run this example you must define an ethernet network uri or ID below
-ethernet_network_id = None
-if ethernet_network_id:
+if ethernet_network_uri:
     print("\nRemove an ethernet network of the uplink set")
-    uplink_set = oneview_client.uplink_sets.remove_ethernet_networks(created_uplink_set['uri'], ethernet_network_id)
+    uplink_set = created_uplink_set.remove_ethernet_networks(ethernet_network_uri)
     print("The uplink set with name = '{name}' have now the networkUris:\n {networkUris}".format(**uplink_set))
 
 # Get the associated ethernet networks of an uplink set
 print("\nGet the associated ethernet networks of the uplink set")
-networks = oneview_client.uplink_sets.get_ethernet_networks(created_uplink_set['uri'])
+networks = created_uplink_set.get_ethernet_networks()
 pprint(networks)
 
 # Delete the recently created uplink set
 print("\nDelete the uplink set")
-oneview_client.fc_networks.delete(updated_uplink_set)
+created_with_uplink_set.delete()
 print("Successfully deleted the uplink set")

--- a/hpOneView/oneview_client.py
+++ b/hpOneView/oneview_client.py
@@ -918,9 +918,7 @@ class OneViewClient(object):
         Returns:
             UplinkSets:
         """
-        if not self.__uplink_sets:
-            self.__uplink_sets = UplinkSets(self.__connection)
-        return self.__uplink_sets
+        return UplinkSets(self.__connection)
 
     @property
     def volumes(self):

--- a/hpOneView/oneview_client.py
+++ b/hpOneView/oneview_client.py
@@ -368,9 +368,7 @@ class OneViewClient(object):
         Returns:
             EthernetNetworks:
         """
-        if not self.__ethernet_networks:
-            self.__ethernet_networks = EthernetNetworks(self.__connection)
-        return self.__ethernet_networks
+        return EthernetNetworks(self.__connection)
 
     @property
     def fabrics(self):

--- a/hpOneView/resources/networking/ethernet_networks.py
+++ b/hpOneView/resources/networking/ethernet_networks.py
@@ -75,7 +75,7 @@ class EthernetNetworks(ResourcePatchMixin, Resource):
 
         """
         uri = self.URI + '/bulk'
-        default_values = self.get_default_values(self.BULK_DEFAULT_VALUES)
+        default_values = self._get_default_values(self.BULK_DEFAULT_VALUES)
         updated_data = self._helper.update_resource_fields(resource, default_values)
 
         self._helper.create(updated_data, uri=uri, timeout=timeout)

--- a/hpOneView/resources/networking/ethernet_networks.py
+++ b/hpOneView/resources/networking/ethernet_networks.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2012-2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2012-2019) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -54,7 +54,7 @@ class EthernetNetworks(ResourcePatchMixin, Resource):
         '300': {"type": "bulk-ethernet-network"},
         '500': {"type": "bulk-ethernet-network"},
         '600': {"type": "bulk-ethernet-networkV1"},
-        '800': {"type": "bulk-ethernet-network"},
+        '800': {"type": "bulk-ethernet-networkV1"},
     }
 
     def __init__(self, connection, data=None):

--- a/hpOneView/resources/networking/ethernet_networks.py
+++ b/hpOneView/resources/networking/ethernet_networks.py
@@ -31,10 +31,11 @@ from future import standard_library
 standard_library.install_aliases()
 
 
-from hpOneView.resources.resource import Resource
+from hpOneView.resources.resource import (Resource, ResourcePatchMixin,
+                                          ensure_resource_client)
 
 
-class EthernetNetworks(Resource):
+class EthernetNetworks(ResourcePatchMixin, Resource):
     """
     Ethernet Networks API client.
 
@@ -74,8 +75,10 @@ class EthernetNetworks(Resource):
 
         """
         uri = self.URI + '/bulk'
-        data = self._helper.add_new_fields(resource, self.BULK_DEFAULT_VALUES)
-        self._request.do_post(uri, data, timeout=timeout)
+        default_values = self.get_default_values(self.BULK_DEFAULT_VALUES)
+        updated_data = self._helper.update_resource_fields(resource, default_values)
+
+        self._helper.create(updated_data, uri=uri, timeout=timeout)
 
         return self.get_range(resource['namePrefix'], resource['vlanIdRange'])
 
@@ -160,7 +163,7 @@ class EthernetNetworks(Resource):
 
         """
         uri = "{}/associatedProfiles".format(self.data['uri'])
-        return self._request.do_get(uri)
+        return self._helper.do_get(uri)
 
     @ensure_resource_client
     def get_associated_uplink_groups(self):
@@ -172,4 +175,4 @@ class EthernetNetworks(Resource):
 
         """
         uri = "{}/associatedUplinkGroups".format(self.data['uri'])
-        return self._request.do_get(uri)
+        return self._helper.do_get(uri)

--- a/hpOneView/resources/networking/ethernet_networks.py
+++ b/hpOneView/resources/networking/ethernet_networks.py
@@ -31,10 +31,10 @@ from future import standard_library
 standard_library.install_aliases()
 
 
-from hpOneView.resources.resource import ResourceClient
+from hpOneView.resources.resource import Resource
 
 
-class EthernetNetworks(object):
+class EthernetNetworks(Resource):
     """
     Ethernet Networks API client.
 
@@ -45,92 +45,19 @@ class EthernetNetworks(object):
         '200': {"type": "ethernet-networkV3"},
         '300': {"type": "ethernet-networkV300"},
         '500': {"type": "ethernet-networkV300"},
-        '600': {"type": "ethernet-networkV4"}
+        '600': {"type": "ethernet-networkV4"},
+        '800': {"type": "ethernet-networkV4"}
     }
     BULK_DEFAULT_VALUES = {
         '200': {"type": "bulk-ethernet-network"},
         '300': {"type": "bulk-ethernet-network"},
         '500': {"type": "bulk-ethernet-network"},
-        '600': {"type": "bulk-ethernet-networkV1"}
+        '600': {"type": "bulk-ethernet-networkV1"},
+        '800': {"type": "bulk-ethernet-network"},
     }
 
-    def __init__(self, con):
-        self._connection = con
-        self._client = ResourceClient(con, self.URI)
-
-    def get_all(self, start=0, count=-1, filter='', sort=''):
-        """
-        Gets a paginated collection of Ethernet networks. The collection is based on optional sorting and filtering
-        and is constrained by start and count parameters.
-
-        Args:
-            start:
-                The first item to return, using 0-based indexing.
-                If not specified, the default is 0 - start with the first available item.
-            count:
-                The number of resources to return. A count of -1 requests all items.
-                The actual number of items in the response might differ from the requested
-                count if the sum of start and count exceeds the total number of items.
-            filter (list or str):
-                A general filter/query string to narrow the list of items returned. The
-                default is no filter; all resources are returned.
-            sort:
-                The sort order of the returned data set. By default, the sort order is based
-                on create time with the oldest entry first.
-
-        Returns:
-            list: A list of ethernet networks.
-        """
-        return self._client.get_all(start, count, filter=filter, sort=sort)
-
-    def delete(self, resource, force=False, timeout=-1):
-        """
-        Deletes an Ethernet network.
-
-        Any deployed connections that are using the network are placed in the 'Failed' state.
-
-        Args:
-            resource: dict object to delete
-            force:
-                 If set to true, the operation completes despite any problems with
-                 network connectivity or errors on the resource itself. The default is false.
-            timeout:
-                Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView; it just stops waiting for its completion.
-
-        Returns:
-            bool: Indicates if the resource was successfully deleted.
-
-        """
-        return self._client.delete(resource, force=force, timeout=timeout)
-
-    def get(self, id_or_uri):
-        """
-        Gets the Ethernet network.
-
-        Args:
-            id_or_uri: ID or URI of Ethernet network.
-
-        Returns:
-            dict: The ethernet network.
-        """
-        return self._client.get(id_or_uri)
-
-    def create(self, resource, timeout=-1):
-        """
-        Creates an Ethernet network.
-
-        Args:
-            resource (dict): Object to create.
-            timeout:
-                Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView; it just stops waiting for its completion.
-
-        Returns:
-            dict: Created resource.
-
-        """
-        return self._client.create(resource, timeout=timeout, default_values=self.DEFAULT_VALUES)
+    def __init__(self, connection, data=None):
+        super(EthernetNetworks, self).__init__(connection, data)
 
     def create_bulk(self, resource, timeout=-1):
         """
@@ -147,7 +74,8 @@ class EthernetNetworks(object):
 
         """
         uri = self.URI + '/bulk'
-        self._client.create(resource, uri=uri, timeout=timeout, default_values=self.BULK_DEFAULT_VALUES)
+        data = self._helper.add_new_fields(resource, self.BULK_DEFAULT_VALUES)
+        self._request.do_post(uri, data, timeout=timeout)
 
         return self.get_range(resource['namePrefix'], resource['vlanIdRange'])
 
@@ -219,36 +147,8 @@ class EthernetNetworks(object):
 
         return vlan_ids
 
-    def update(self, resource, timeout=-1):
-        """
-        Updates an Ethernet network.
-
-        Args:
-            resource: dict object to update
-            timeout:
-                Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView; it just stops waiting for its completion.
-
-        Returns: Updated resource.
-
-        """
-        return self._client.update(resource, timeout=timeout, default_values=self.DEFAULT_VALUES)
-
-    def get_by(self, field, value):
-        """
-        Gets all Ethernet networks that match the filter.
-        The search is case-insensitive.
-
-        Args:
-            field: field name to filter
-            value: value to filter
-
-        Returns:
-            list: A list of ethernet networks.
-        """
-        return self._client.get_by(field, value)
-
-    def get_associated_profiles(self, id_or_uri):
+    @ensure_resource_client
+    def get_associated_profiles(self):
         """
         Gets the URIs of profiles which are using an Ethernet network.
 
@@ -259,38 +159,17 @@ class EthernetNetworks(object):
             list: URIs of the associated profiles.
 
         """
-        uri = self._client.build_uri(id_or_uri) + "/associatedProfiles"
-        return self._client.get(uri)
+        uri = "{}/associatedProfiles".format(self.data['uri'])
+        return self._request.do_get(uri)
 
-    def get_associated_uplink_groups(self, id_or_uri):
+    @ensure_resource_client
+    def get_associated_uplink_groups(self):
         """
         Gets the uplink sets which are using an Ethernet network.
-
-        Args:
-            id_or_uri: Can be either the logical interconnect group id or the logical interconnect group uri
 
         Returns:
             list: URIs of the associated uplink sets.
 
         """
-        uri = self._client.build_uri(id_or_uri) + "/associatedUplinkGroups"
-        return self._client.get(uri)
-
-    def patch(self, id_or_uri, operation, path, value, timeout=-1):
-        """
-        Uses the PATCH to update the given resource.
-
-        Only one operation can be performed in each PATCH call.
-
-        Args:
-            id_or_uri: Can be either the resource ID or the resource URI.
-            operation: Patch operation
-            path: Path
-            value: Value
-            timeout: Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView; it just stops waiting for its completion.
-
-        Returns:
-            dict: Updated resource.
-        """
-        return self._client.patch(id_or_uri, operation, path, value, timeout=timeout)
+        uri = "{}/associatedUplinkGroups".format(self.data['uri'])
+        return self._request.do_get(uri)

--- a/hpOneView/resources/networking/uplink_sets.py
+++ b/hpOneView/resources/networking/uplink_sets.py
@@ -31,12 +31,12 @@ from future import standard_library
 standard_library.install_aliases()
 
 
-from hpOneView.resources.resource import ResourceClient
+from hpOneView.resources.resource import Resource, ensure_resource_client
 from hpOneView.resources.networking.ethernet_networks import EthernetNetworks
 from builtins import isinstance
 
 
-class UplinkSets(object):
+class UplinkSets(Resource):
     """
     Uplink Sets API client.
 
@@ -47,120 +47,16 @@ class UplinkSets(object):
         '200': {"type": "uplink-setV3"},
         '300': {"type": "uplink-setV300"},
         '500': {"type": "uplink-setV300"},
-        '600': {"type": "uplink-setV4"}
+        '600': {"type": "uplink-setV4"},
+        '800': {"type": "uplink-setV4"}
     }
 
-    def __init__(self, con):
-        self._connection = con
-        self._client = ResourceClient(con, self.URI)
-        self._ethernet_network = EthernetNetworks(con)
+    def __init__(self, connection, data=None):
+        super(UplinkSets, self).__init__(connection, data)
+        self._ethernet_network = EthernetNetworks(connection)
 
-    def get_all(self, start=0, count=-1, filter='', sort=''):
-        """
-        Gets a paginated list of uplink sets based on optional sorting and filtering and is constrained by start and
-        count parameters.
-
-        Filters can be used in the URL to control the number of uplink sets that are returned.
-        With no filters specified, the API returns all uplink sets.
-
-        Args:
-            start:
-                The first item to return, using 0-based indexing.
-                If not specified, the default is 0 - start with the first available item.
-            count:
-                The number of resources to return. A count of -1 requests all items.
-                The actual number of items in the response might differ from the requested
-                count if the sum of start and count exceeds the total number of items.
-            filter (list or str):
-                A general filter/query string to narrow the list of items returned. The
-                default is no filter; all resources are returned.
-            sort:
-                The sort order of the returned data set. By default, the sort order is based
-                on create time with the oldest entry first.
-
-        Returns:
-            list: A list of uplink sets.
-        """
-        return self._client.get_all(start, count, filter=filter, sort=sort)
-
-    def get(self, id_or_uri):
-        """
-        Gets an uplink set with the specified ID.
-
-        Args:
-            id_or_uri: Can be either the uplink set id or the uplink set uri.
-
-        Returns:
-            dict: The uplink set.
-        """
-        return self._client.get(id_or_uri)
-
-    def get_by(self, field, value):
-        """
-        Gets all uplink sets that match the filter.
-
-        The search is case-insensitive.
-
-        Args:
-            field: Field name to filter.
-            value: Value to filter.
-
-        Returns:
-            list: Uplink sets
-
-        """
-        return self._client.get_by(field, value)
-
-    def create(self, resource, timeout=-1):
-        """
-        Creates an uplink set.
-
-        Args:
-            resource (dict): Object to create.
-            timeout:
-                Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation in
-                OneView, just stops waiting for its completion.
-
-        Returns:
-            dict: Created resource.
-        """
-        return self._client.create(resource, timeout=timeout, default_values=self.DEFAULT_VALUES)
-
-    def update(self, resource, timeout=-1):
-        """
-        Updates an uplink set.
-
-        Args:
-            resource (dict): Resource to update.
-            timeout:
-                Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation in
-                OneView, just stops waiting for its completion.
-
-        Returns:
-            dict: Updated resource.
-        """
-        return self._client.update(resource, timeout=timeout, default_values=self.DEFAULT_VALUES)
-
-    def delete(self, resource, force=False, timeout=-1):
-        """
-        Deletes an uplink set. If the uplink set was carrying a Fibre Channel (FC) network, any connections which are
-        deployed and using the FC network will be placed into a 'Failed' state.
-
-        Args:
-            resource: Resource to delete or the resource ID.
-            force:
-                 If set to true, the operation completes despite any problems with
-                 network connectivity or errors on the resource itself. The default is false.
-            timeout:
-                Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation in
-                OneView, just stops waiting for its completion.
-
-            Returns:
-                bool: True if successfully deleted.
-        """
-        return self._client.delete(resource, force=force, timeout=timeout)
-
-    def get_ethernet_networks(self, id_or_uri):
+    @ensure_resource_client
+    def get_ethernet_networks(self):
         """
         Gets a list of associated ethernet networks of an uplink set.
 
@@ -170,15 +66,15 @@ class UplinkSets(object):
         Returns:
             list: Associated ethernet networks.
         """
-        uplink = self.get(id_or_uri)
-        network_uris = uplink.get('networkUris')
+        network_uris = self.data.get('networkUris')
         networks = []
         if network_uris:
             for uri in network_uris:
-                networks.append(self._ethernet_network.get(uri))
+                networks.append(self._ethernet_network.get_by_uri(uri))
         return networks
 
-    def add_ethernet_networks(self, id_or_uri, ethernet_id_or_uris):
+    @ensure_resource_client
+    def add_ethernet_networks(self, ethernet_id_or_uris):
         """
         Adds existing ethernet networks to an uplink set.
 
@@ -191,9 +87,10 @@ class UplinkSets(object):
         Returns:
             dict: The updated uplink set.
         """
-        return self.__set_ethernet_uris(id_or_uri, ethernet_id_or_uris, operation="add")
+        return self.__set_ethernet_uris(ethernet_id_or_uris, operation="add")
 
-    def remove_ethernet_networks(self, id_or_uri, ethernet_id_or_uris):
+    @ensure_resource_client
+    def remove_ethernet_networks(self, ethernet_id_or_uris):
         """
         Remove existing ethernet networks of an uplink set.
 
@@ -208,13 +105,11 @@ class UplinkSets(object):
         """
         return self.__set_ethernet_uris(id_or_uri, ethernet_id_or_uris, operation="remove")
 
-    def __set_ethernet_uris(self, id_or_uri, ethernet_id_or_uris, operation="add"):
+    def __set_ethernet_uris(self, ethernet_id_or_uris, operation="add"):
         if not isinstance(ethernet_id_or_uris, list):
             ethernet_id_or_uris = [ethernet_id_or_uris]
 
-        uplink = self.get(id_or_uri)
-
-        associated_enets = uplink.get('networkUris', [])
+        associated_enets = self.data.get('networkUris', [])
 
         for i, enet in enumerate(ethernet_id_or_uris):
             ethernet_id_or_uris[i] = enet if '/' in enet else self._ethernet_network.URI + '/' + enet
@@ -227,7 +122,7 @@ class UplinkSets(object):
             raise ValueError("Value {} is not supported as operation. The supported values are: ['add', 'remove']")
 
         if set(enets_to_update) != set(associated_enets):
-            uplink['networkUris'] = enets_to_update
-            return self.update(uplink)
+            updated_network = {'networkUris': enets_to_update}
+            return self.update(updated_network)
         else:
             return uplink

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -180,9 +180,7 @@ class Resource(object):
             data = {}
 
         default_values = self._get_default_values()
-        for key, value in default_values.items():
-            if not data.get(key):
-                data[key] = value
+        data = self._helper.add_new_fields(data, default_values)
 
         logger.debug('Create (uri = %s, resource = %s)' % (uri, str(data)))
 
@@ -658,6 +656,22 @@ class ResourceHelper(object):
             return body
 
         return self._task_monitor.wait_for_task(task, timeout)
+
+    def add_new_fields(data, data_to_add):
+       """Update resource data with new fields.
+
+       Args:
+           data: resource data
+           data_to_update: dict of data to update resource data
+
+       Returnes:
+           Returnes dict
+       """
+       for key, value in data_to_add.items():
+            if not data.get(key):
+                data[key] = value
+
+       return data
 
 
 class ResourcePatchMixin(object):

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -576,20 +576,20 @@ class ResourceHelper(object):
             return []
 
     def update_resource_fields(self, data, data_to_add):
-       """Update resource data with new fields.
+        """Update resource data with new fields.
 
-       Args:
-           data: resource data
-           data_to_update: dict of data to update resource data
+        Args:
+            data: resource data
+            data_to_update: dict of data to update resource data
 
-       Returnes:
-           Returnes dict
-       """
-       for key, value in data_to_add.items():
+        Returnes:
+            Returnes dict
+        """
+        for key, value in data_to_add.items():
             if not data.get(key):
                 data[key] = value
 
-       return data
+        return data
 
     def do_requests_to_getall(self, uri, requested_count):
         """Helps to make http request for get_all method.

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -179,8 +179,8 @@ class Resource(object):
         if not data:
             data = {}
 
-        default_values = self._get_default_values()
-        data = self._helper.add_new_fields(data, default_values)
+        default_values = self.get_default_values()
+        data = self._helper.update_resource_fields(data, default_values)
 
         logger.debug('Create (uri = %s, resource = %s)' % (uri, str(data)))
 
@@ -296,12 +296,15 @@ class Resource(object):
 
         return new_resource
 
-    def _get_default_values(self):
+    def get_default_values(self, default_values=None):
         """Gets the default values set for a resource"""
 
-        if self.DEFAULT_VALUES:
+        if not default_values:
+            default_values = self.DEFAULT_VALUES
+
+        if default_values:
             api_version = str(self._connection._apiVersion)
-            values = self.DEFAULT_VALUES.get(api_version, {}).copy()
+            values = default_values.get(api_version, {}).copy()
         else:
             values = {}
 
@@ -309,7 +312,7 @@ class Resource(object):
 
     def _merge_default_values(self):
         """Merge default values with resource data."""
-        values = self._get_default_values()
+        values = self.get_default_values()
         for key, value in values.items():
             if not self.data.get(key):
                 self.data[key] = value
@@ -572,6 +575,22 @@ class ResourceHelper(object):
         else:
             return []
 
+    def update_resource_fields(self, data, data_to_add):
+       """Update resource data with new fields.
+
+       Args:
+           data: resource data
+           data_to_update: dict of data to update resource data
+
+       Returnes:
+           Returnes dict
+       """
+       for key, value in data_to_add.items():
+            if not data.get(key):
+                data[key] = value
+
+       return data
+
     def do_requests_to_getall(self, uri, requested_count):
         """Helps to make http request for get_all method.
 
@@ -676,6 +695,7 @@ class ResourceHelper(object):
 
 class ResourcePatchMixin(object):
 
+    @ensure_resource_client
     def patch(self, operation, path, value, custom_headers=None, timeout=-1):
         """Uses the PATCH to update a resource.
 

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -179,7 +179,7 @@ class Resource(object):
         if not data:
             data = {}
 
-        default_values = self.get_default_values()
+        default_values = self._get_default_values()
         data = self._helper.update_resource_fields(data, default_values)
 
         logger.debug('Create (uri = %s, resource = %s)' % (uri, str(data)))
@@ -296,7 +296,7 @@ class Resource(object):
 
         return new_resource
 
-    def get_default_values(self, default_values=None):
+    def _get_default_values(self, default_values=None):
         """Gets the default values set for a resource"""
 
         if not default_values:
@@ -312,7 +312,7 @@ class Resource(object):
 
     def _merge_default_values(self):
         """Merge default values with resource data."""
-        values = self.get_default_values()
+        values = self._get_default_values()
         for key, value in values.items():
             if not self.data.get(key):
                 self.data[key] = value
@@ -677,20 +677,20 @@ class ResourceHelper(object):
         return self._task_monitor.wait_for_task(task, timeout)
 
     def add_new_fields(data, data_to_add):
-       """Update resource data with new fields.
+        """Update resource data with new fields.
 
-       Args:
-           data: resource data
-           data_to_update: dict of data to update resource data
+        Args:
+            data: resource data
+            data_to_update: dict of data to update resource data
 
-       Returnes:
-           Returnes dict
-       """
-       for key, value in data_to_add.items():
+        Returnes:
+            Returnes dict
+        """
+        for key, value in data_to_add.items():
             if not data.get(key):
                 data[key] = value
 
-       return data
+        return data
 
 
 class ResourcePatchMixin(object):

--- a/tests/unit/resources/networking/test_ethernet_networks.py
+++ b/tests/unit/resources/networking/test_ethernet_networks.py
@@ -27,7 +27,7 @@ import mock
 
 from hpOneView.connection import connection
 from hpOneView.resources.networking.ethernet_networks import EthernetNetworks
-from hpOneView.resources.resource import ResourceClient
+from hpOneView.resources.resource import Resource, ResourcePatchMixin, ResourceHelper
 
 
 class EthernetNetworksTest(TestCase):
@@ -36,16 +36,16 @@ class EthernetNetworksTest(TestCase):
         self.connection = connection(self.host)
         self._ethernet_networks = EthernetNetworks(self.connection)
 
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(ResourceHelper, 'get_all')
     def test_get_all_called_once(self, mock_get_all):
         filter = 'name=TestName'
         sort = 'name:ascending'
 
         self._ethernet_networks.get_all(2, 500, filter, sort)
 
-        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort)
+        mock_get_all.assert_called_once_with(count=500, filter=filter, sort=sort, start=2)
 
-    @mock.patch.object(ResourceClient, 'create')
+    @mock.patch.object(ResourceHelper, 'create')
     def test_create_should_use_given_values(self, mock_create):
         resource = {
             'vlanId': 10,
@@ -57,27 +57,14 @@ class EthernetNetworksTest(TestCase):
             "privateNetwork": False
         }
         resource_rest_call = resource.copy()
+        resource_rest_call['type'] = 'ethernet-networkV300'
         mock_create.return_value = {}
 
-        self._ethernet_networks.create(resource, 12)
-        mock_create.assert_called_once_with(resource_rest_call, timeout=12,
-                                            default_values=self._ethernet_networks.DEFAULT_VALUES)
+        self._ethernet_networks.create(resource, timeout=12)
+        mock_create.assert_called_once_with(resource_rest_call, None, 12, None)
 
-    @mock.patch.object(ResourceClient, 'create')
-    def test_create_should_use_default_values(self, mock_create):
-        resource = {
-            'name': 'OneViewSDK Test Ethernet Network',
-        }
-
-        mock_create.return_value = {}
-
-        self._ethernet_networks.create(resource)
-
-        mock_create.assert_called_once_with(resource, timeout=-1,
-                                            default_values=self._ethernet_networks.DEFAULT_VALUES)
-
-    @mock.patch.object(ResourceClient, 'create')
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(ResourceHelper, 'create')
+    @mock.patch.object(Resource, 'get_all')
     def test_create_bulk(self, mock_get_all, mock_create):
         resource = {
             'vlanIdRange': '1-10',
@@ -91,17 +78,19 @@ class EthernetNetworksTest(TestCase):
             }
         }
         resource_rest_call = resource.copy()
+        resource_rest_call['type'] = 'bulk-ethernet-network'
+
         mock_create.return_value = {}
         mock_get_all.return_value = []
 
         self._ethernet_networks.create_bulk(resource, 27)
 
         mock_create.assert_called_once_with(
-            resource_rest_call, uri='/rest/ethernet-networks/bulk', timeout=27, default_values=self._ethernet_networks.BULK_DEFAULT_VALUES)
+            resource_rest_call, uri='/rest/ethernet-networks/bulk', timeout=27)
         mock_get_all.assert_called_once_with(
-            0, -1, filter='"\'name\' matches \'TestNetwork\\_%\'"', sort='vlanId:ascending')
+            filter='"\'name\' matches \'TestNetwork\\_%\'"', sort='vlanId:ascending')
 
-    @mock.patch.object(ResourceClient, 'update')
+    @mock.patch.object(Resource, 'update')
     def test_update_should_use_given_values(self, mock_update):
         resource = {
             'name': 'OneViewSDK Test Ethernet Network',
@@ -116,10 +105,9 @@ class EthernetNetworksTest(TestCase):
         mock_update.return_value = {}
 
         self._ethernet_networks.update(resource, timeout=60)
-        mock_update.assert_called_once_with(resource_rest_call, timeout=60,
-                                            default_values=self._ethernet_networks.DEFAULT_VALUES)
+        mock_update.assert_called_once_with(resource_rest_call, timeout=60)
 
-    @mock.patch.object(ResourceClient, 'update')
+    @mock.patch.object(Resource, 'update')
     def test_update_should_use_default_values(self, mock_update):
         resource = {
             'name': 'OneViewSDK Test Ethernet Network',
@@ -129,16 +117,16 @@ class EthernetNetworksTest(TestCase):
 
         self._ethernet_networks.update(resource)
 
-        mock_update.assert_called_once_with(resource, timeout=-1, default_values=self._ethernet_networks.DEFAULT_VALUES)
+        mock_update.assert_called_once_with(resource)
 
-    @mock.patch.object(ResourceClient, 'delete')
+    @mock.patch.object(Resource, 'delete')
     def test_delete_called_once(self, mock_delete):
         id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
         self._ethernet_networks.delete(id, force=False, timeout=-1)
 
         mock_delete.assert_called_once_with(id, force=False, timeout=-1)
 
-    @mock.patch.object(ResourceClient, 'get_by')
+    @mock.patch.object(Resource, 'get_by')
     def test_get_by_called_once(self, mock_get_by):
         self._ethernet_networks.get_by(
             'name', 'OneViewSDK Test Ethernet Network')
@@ -146,48 +134,22 @@ class EthernetNetworksTest(TestCase):
         mock_get_by.assert_called_once_with(
             'name', 'OneViewSDK Test Ethernet Network')
 
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_called_once(self, mock_get):
-        self._ethernet_networks.get('3518be0e-17c1-4189-8f81-83f3724f6155')
-
-        mock_get.assert_called_once_with(
-            '3518be0e-17c1-4189-8f81-83f3724f6155')
-
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_with_uri_called_once(self, mock_get):
-        uri = '/rest/ethernet-networks/3518be0e-17c1-4189-8f81-83f3724f6155'
-        self._ethernet_networks.get(uri)
-
-        mock_get.assert_called_once_with(uri)
-
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_associated_uplink_groups_uri_called_once_with_id(self, mock_get):
-        self._ethernet_networks.get_associated_uplink_groups(
-            '3518be0e-17c1-4189-8f81-83f3724f6155')
-        uri = '/rest/ethernet-networks/3518be0e-17c1-4189-8f81-83f3724f6155/associatedUplinkGroups'
-
-        mock_get.assert_called_once_with(uri)
-
-    @mock.patch.object(ResourceClient, 'get')
+    @mock.patch.object(ResourceHelper, 'do_get')
     def test_get_associated_uplink_groups_uri_called_once_with_uri(self, mock_get):
-        self._ethernet_networks.get_associated_uplink_groups(
-            '/rest/ethernet-networks/3518be0e-17c1-4189-8f81-83f3724f6155')
+        self._ethernet_networks.data = {"name": "name",
+                                        "uri": "/rest/ethernet-networks/3518be0e-17c1-4189-8f81-83f3724f6155"}
+        self._ethernet_networks.get_associated_uplink_groups()
+
         uri = '/rest/ethernet-networks/3518be0e-17c1-4189-8f81-83f3724f6155/associatedUplinkGroups'
 
         mock_get.assert_called_once_with(uri)
 
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_associated_profiles_called_once_with_id(self, mock_get):
-        self._ethernet_networks.get_associated_profiles(
-            '3518be0e-17c1-4189-8f81-83f3724f6155')
-        uri = '/rest/ethernet-networks/3518be0e-17c1-4189-8f81-83f3724f6155/associatedProfiles'
-
-        mock_get.assert_called_once_with(uri)
-
-    @mock.patch.object(ResourceClient, 'get')
+    @mock.patch.object(ResourceHelper, 'do_get')
     def test_get_associated_profiles_called_once_with_uri(self, mock_get):
-        self._ethernet_networks.get_associated_profiles(
-            '/rest/ethernet-networks/3518be0e-17c1-4189-8f81-83f3724f6155')
+        self._ethernet_networks.data = {"name": "name",
+                                        "uri": "/rest/ethernet-networks/3518be0e-17c1-4189-8f81-83f3724f6155"}
+        self._ethernet_networks.get_associated_profiles()
+
         uri = '/rest/ethernet-networks/3518be0e-17c1-4189-8f81-83f3724f6155/associatedProfiles'
 
         mock_get.assert_called_once_with(uri)
@@ -271,13 +233,15 @@ class EthernetNetworksTest(TestCase):
         result = self._ethernet_networks.get_range('TestNetwork', '6-7,9-10')
         self.assertEqual(result, expected_result)
 
-    @mock.patch.object(ResourceClient, 'patch')
-    def test_patch_should_use_user_defined_values(self, mock_patch):
+    @mock.patch.object(ResourcePatchMixin, 'patch_request')
+    @mock.patch.object(Resource, 'get_by')
+    def test_patch_should_use_user_defined_values(self, mock_get_by, mock_patch):
         mock_patch.return_value = {}
-
-        self._ethernet_networks.patch('/rest/fake/ethernet123', 'replace', '/scopeUris', ['/rest/fake/scope123'], 1)
-        mock_patch.assert_called_once_with('/rest/fake/ethernet123', 'replace', '/scopeUris',
-                                           ['/rest/fake/scope123'], timeout=1)
+        self._ethernet_networks.data = {"name": "test name", "uri": "/rest/test"}
+        self._ethernet_networks.patch('replace', '/scopeUris', ['/rest/fake/scope123'], 1)
+        mock_patch.assert_called_once_with('/rest/test',
+                                           body=[{u'path': '/scopeUris', u'value': ['/rest/fake/scope123'], u'op': 'replace'}],
+                                           custom_headers=1, timeout=-1)
 
     def test_dissociate_values_or_ranges_with_one_value(self):
         expected_result = [1, 2, 3, 4, 5]

--- a/tests/unit/resources/networking/test_ethernet_networks.py
+++ b/tests/unit/resources/networking/test_ethernet_networks.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2012-2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2012-2019) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the 'Software'), to deal

--- a/tests/unit/resources/networking/test_uplink_sets.py
+++ b/tests/unit/resources/networking/test_uplink_sets.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2012-2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2012-2019) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,7 @@ import mock
 from hpOneView.connection import connection
 from hpOneView.resources.networking.ethernet_networks import EthernetNetworks
 from hpOneView.resources.networking.uplink_sets import UplinkSets
-from hpOneView.resources.resource import ResourceClient
+from hpOneView.resources.resource import Resource, ResourceHelper
 
 
 class UplinkSetsTest(unittest.TestCase):
@@ -36,39 +36,35 @@ class UplinkSetsTest(unittest.TestCase):
         self.host = '127.0.0.1'
         self.connection = connection(self.host)
         self._uplink_sets = UplinkSets(self.connection)
+        self._uplink_sets.data = {'uri': '/rest/ul-inksets/ad28cf21-8b15-4f92-bdcf-51cb2042db32'}
+        self._ethernet_networks = EthernetNetworks(self.connection)
 
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(ResourceHelper, 'get_all')
     def test_get_all_called_once(self, mock_get_all):
         filter = 'name=TestName'
         sort = 'name:ascending'
         self._uplink_sets.get_all(2, 500, filter, sort)
-        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort)
+        mock_get_all.assert_called_once_with(start=2, count=500, filter=filter, sort=sort)
 
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(ResourceHelper, 'get_all')
     def test_get_all_called_once_with_defaults(self, mock_get_all):
         self._uplink_sets.get_all()
-        mock_get_all.assert_called_once_with(0, -1, filter='', sort='')
+        mock_get_all.assert_called_once_with(count=-1, filter='', sort='', start=0)
 
-    @mock.patch.object(ResourceClient, 'get_by')
+    @mock.patch.object(Resource, 'get_by')
     def test_get_by_called_once(self, mock_get_by):
         self._uplink_sets.get_by('name', 'OneViewSDK Test Uplink Set')
 
         mock_get_by.assert_called_once_with('name', 'OneViewSDK Test Uplink Set')
 
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_called_once(self, mock_get):
-        self._uplink_sets.get('3518be0e-17c1-4189-8f81-83f3724f6155')
-
-        mock_get.assert_called_once_with('3518be0e-17c1-4189-8f81-83f3724f6155')
-
-    @mock.patch.object(ResourceClient, 'get')
+    @mock.patch.object(Resource, 'get_by_uri')
     def test_get_with_uri_called_once(self, mock_get):
         uri = '/rest/uplink-sets/3518be0e-17c1-4189-8f81-83f3724f6155'
-        self._uplink_sets.get(uri)
+        self._uplink_sets.get_by_uri(uri)
 
         mock_get.assert_called_once_with(uri)
 
-    @mock.patch.object(ResourceClient, 'create')
+    @mock.patch.object(ResourceHelper, 'create')
     def test_create_should_be_called_once(self, mock_create):
         resource = {
             "type": "uplink-setV3",
@@ -77,9 +73,9 @@ class UplinkSetsTest(unittest.TestCase):
         mock_create.return_value = {}
 
         self._uplink_sets.create(resource, 60)
-        mock_create.assert_called_once_with(resource, timeout=60, default_values=self._uplink_sets.DEFAULT_VALUES)
+        mock_create.assert_called_once_with(resource, 60, -1, None)
 
-    @mock.patch.object(ResourceClient, 'update')
+    @mock.patch.object(Resource, 'update')
     def test_update_should_be_called_once(self, mock_update):
         resource = {
             "name": "uls2",
@@ -87,19 +83,16 @@ class UplinkSetsTest(unittest.TestCase):
         mock_update.return_value = {}
 
         self._uplink_sets.update(resource)
-        mock_update.assert_called_once_with(resource, timeout=-1, default_values=self._uplink_sets.DEFAULT_VALUES)
+        mock_update.assert_called_once_with(resource)
 
-    @mock.patch.object(ResourceClient, 'delete')
+    @mock.patch.object(Resource, 'delete')
     def test_delete_called_once(self, mock_delete):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
-        self._uplink_sets.delete(id, force=False, timeout=-1)
+        self._uplink_sets.delete(force=False, timeout=-1)
 
-        mock_delete.assert_called_once_with(id, force=False, timeout=-1)
+        mock_delete.assert_called_once_with(force=False, timeout=-1)
 
-    @mock.patch.object(EthernetNetworks, 'get')
-    @mock.patch.object(UplinkSets, 'get')
-    def test_get_ethernet_networks(self, mock_uplink_get, mock_get_enet):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+    @mock.patch.object(EthernetNetworks, 'get_by_uri')
+    def test_get_ethernet_networks(self, mock_get_enet):
         uplink = {
             'name': 'UplinkName',
             'networkUris': ['/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
@@ -114,252 +107,188 @@ class UplinkSetsTest(unittest.TestCase):
             {'name': 'Ethernet Network 3'},
         ]
 
-        mock_uplink_get.return_value = uplink
+        self._uplink_sets.data = uplink
         mock_get_enet.side_effect = result_get_enet
-        result = self._uplink_sets.get_ethernet_networks(id)
+        result = self._uplink_sets.get_ethernet_networks()
+
         self.assertEqual(mock_get_enet.call_count, 3)
         self.assertEqual(result_get_enet, result)
 
-    @mock.patch.object(UplinkSets, 'get')
+    @mock.patch.object(UplinkSets, 'get_by_uri')
     def test_get_ethernet_networks_with_empty_list(self, mock_uplink_get):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
         uplink = {
             'name': 'UplinkName',
         }
 
-        mock_uplink_get.return_value = uplink
-        result = self._uplink_sets.get_ethernet_networks(id)
+        mock_uplink_get.return_value = None
+        self._uplink_sets.data = uplink
+        result = self._uplink_sets.get_ethernet_networks()
         self.assertEqual([], result)
 
     @mock.patch.object(UplinkSets, 'update')
-    @mock.patch.object(UplinkSets, 'get')
-    def test_add_one_ethernet_network(self, mock_uplink_get, mock_uplink_update):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
-        ethernet_to_add = '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939'
+    @mock.patch.object(EthernetNetworks, 'get_by_name')
+    def test_add_one_ethernet_network(self, mock_ethnet_get, mock_uplink_update):
+        ethernet_to_add = 'eth1'
         uplink = {
             'name': 'UplinkName',
         }
 
         uplink_to_update = {
-            'name': 'UplinkName',
             'networkUris': ['/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939', ]
         }
 
-        mock_uplink_get.return_value = uplink
-        self._uplink_sets.add_ethernet_networks(id, ethernet_to_add)
+        self._ethernet_networks.data = {'uri': '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939'}
+        mock_ethnet_get.return_value = self._ethernet_networks
+
+        self._uplink_sets.data = uplink
+        self._uplink_sets.add_ethernet_networks(ethernet_to_add)
         mock_uplink_update.assert_called_once_with(uplink_to_update)
 
     @mock.patch.object(UplinkSets, 'update')
-    @mock.patch.object(UplinkSets, 'get')
-    def test_add_a_list_of_ethernet_networks(self, mock_uplink_get, mock_uplink_update):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+    @mock.patch.object(EthernetNetworks, 'get_by_name')
+    def test_add_a_list_of_ethernet_networks(self, mock_ethnet_get, mock_uplink_update):
         ethernet_to_add = [
-            '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
-            '/rest/ethernet-networks/134dcf5e-0d8e-441c-b00d-e1dd6a067188',
+            'eth1',
+            'eth2',
         ]
-        uplink = {
-            'name': 'UplinkName',
-        }
 
         uplink_to_update = {
-            'name': 'UplinkName',
             'networkUris': ['/rest/ethernet-networks/134dcf5e-0d8e-441c-b00d-e1dd6a067188',
                             '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939', ]
         }
 
-        mock_uplink_get.return_value = uplink
-        self._uplink_sets.add_ethernet_networks(id, ethernet_to_add)
+        eth1 = self._ethernet_networks
+        eth2 = EthernetNetworks(self.connection)
+        eth1.data = {'name': 'eth1', 'uri': '/rest/ethernet-networks/134dcf5e-0d8e-441c-b00d-e1dd6a067188'}
+        eth2.data = {'name': 'eth2', 'uri': '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939'}
+        result_get_enet = [eth1, eth2]
+
+        mock_ethnet_get.side_effect = result_get_enet
+
+        self._uplink_sets.add_ethernet_networks(ethernet_to_add)
         mock_uplink_update.assert_called_once_with(uplink_to_update)
 
     @mock.patch.object(UplinkSets, 'update')
-    @mock.patch.object(UplinkSets, 'get')
-    def test_add_a_list_of_ethernet_network_uris(self, mock_uplink_get, mock_uplink_update):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
+    @mock.patch.object(EthernetNetworks, 'get_by_name')
+    def test_add_missing_ethernet_networks(self, mock_ethnet_get, mock_uplink_update):
         ethernet_to_add = [
-            '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
-            '/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188',
-        ]
-        uplink = {
-            'name': 'UplinkName',
-        }
-
-        uplink_to_update = {
-            'name': 'UplinkName',
-            'networkUris': ['/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
-                            '/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188', ]
-        }
-
-        mock_uplink_get.return_value = uplink
-        self._uplink_sets.add_ethernet_networks(id, ethernet_to_add)
-        mock_uplink_update.assert_called_once_with(uplink_to_update)
-
-    @mock.patch.object(UplinkSets, 'update')
-    @mock.patch.object(UplinkSets, 'get')
-    def test_add_a_list_of_ethernet_network_ids(self, mock_uplink_get, mock_uplink_update):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
-        ethernet_to_add = [
-            '5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
-            'd34dcf5e-0d8e-441c-b00d-e1dd6a067188',
-        ]
-        uplink = {
-            'name': 'UplinkName',
-        }
-        uplink_to_update = {
-            'name': 'UplinkName',
-            'networkUris': ['/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
-                            '/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188', ]
-        }
-        uplink_return = uplink_to_update.copy()
-
-        mock_uplink_update.return_value = uplink_return
-        mock_uplink_get.return_value = uplink
-
-        result = self._uplink_sets.add_ethernet_networks(id, ethernet_to_add)
-        mock_uplink_update.assert_called_once_with(uplink_to_update)
-        self.assertEqual(uplink_return, result)
-
-    @mock.patch.object(UplinkSets, 'update')
-    @mock.patch.object(UplinkSets, 'get')
-    def test_add_missing_ethernet_networks(self, mock_uplink_get, mock_uplink_update):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
-        ethernet_to_add = [
-            '5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
-            'd34dcf5e-0d8e-441c-b00d-e1dd6a067188',
+            'eth1',
+            'eth2',
         ]
         uplink = {
             'name': 'UplinkName',
             'networkUris': ['/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188', ]
         }
         uplink_to_update = {
-            'name': 'UplinkName',
             'networkUris': ['/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
                             '/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188', ]
         }
-        uplink_return = uplink_to_update.copy()
 
-        mock_uplink_get.return_value = uplink
-        mock_uplink_update.return_value = uplink_return
+        eth1 = self._ethernet_networks
+        eth2 = EthernetNetworks(self.connection)
+        eth1.data = {'name': 'eth1', 'uri': '/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188'}
+        eth2.data = {'name': 'eth2', 'uri': '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939'}
+        result_get_enet = [eth1, eth2]
 
-        result = self._uplink_sets.add_ethernet_networks(id, ethernet_to_add)
+        self._uplink_sets.data = uplink
+        mock_ethnet_get.side_effect = result_get_enet
+
+        self._uplink_sets.add_ethernet_networks(ethernet_to_add)
         mock_uplink_update.assert_called_once_with(uplink_to_update)
-        self.assertEqual(uplink_return, result)
 
     @mock.patch.object(UplinkSets, 'update')
-    @mock.patch.object(UplinkSets, 'get')
+    @mock.patch.object(EthernetNetworks, 'get_by_name')
     def test_not_add_ethernet_networks_already_associated(self, mock_uplink_get, mock_uplink_update):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
         ethernet_to_add = [
-            'd34dcf5e-0d8e-441c-b00d-e1dd6a067188',
+            'eth1',
         ]
+
         uplink = {
             'name': 'UplinkName',
             'networkUris': ['/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188', ]
         }
 
-        mock_uplink_get.return_value = uplink
-        result = self._uplink_sets.add_ethernet_networks(id, ethernet_to_add)
+        self._ethernet_networks.data = {'uri': '/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188'}
+        mock_uplink_get.return_value = self._ethernet_networks
+
+        self._uplink_sets.data = uplink
+        result = self._uplink_sets.add_ethernet_networks(ethernet_to_add)
         self.assertEqual(mock_uplink_update.call_count, 0)
         self.assertEqual(uplink, result)
 
     @mock.patch.object(UplinkSets, 'update')
-    @mock.patch.object(UplinkSets, 'get')
-    def test_remove_one_ethernet_network(self, mock_uplink_get, mock_uplink_update):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
-        ethernet_to_remove = '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939'
+    @mock.patch.object(EthernetNetworks, 'get_by_name')
+    def test_remove_one_ethernet_network(self, mock_ethernet_get, mock_uplink_update):
+        ethernet_to_remove = 'eth1'
         uplink = {
             'name': 'UplinkName',
             'networkUris': ['/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939', ]
         }
 
         uplink_to_update = {
-            'name': 'UplinkName',
             'networkUris': []
         }
 
-        mock_uplink_get.return_value = uplink
-        self._uplink_sets.remove_ethernet_networks(id, ethernet_to_remove)
+        self._ethernet_networks.data = {'uri': '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939'}
+        mock_ethernet_get.return_value = self._ethernet_networks
+
+        self._uplink_sets.data = uplink
+        self._uplink_sets.remove_ethernet_networks(ethernet_to_remove)
         mock_uplink_update.assert_called_once_with(uplink_to_update)
 
     @mock.patch.object(UplinkSets, 'update')
-    @mock.patch.object(UplinkSets, 'get')
-    def test_remove_a_list_of_ethernet_networks(self, mock_uplink_get, mock_uplink_update):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
-        ethernet_to_remove = [
-            '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
-            '/rest/ethernet-networks/134dcf5e-0d8e-441c-b00d-e1dd6a067188',
-        ]
+    @mock.patch.object(EthernetNetworks, 'get_by_name')
+    def test_remove_a_list_of_ethernet_networks(self, mock_ethernet_get, mock_uplink_update):
+        ethernet_to_remove = ['eth1']
+
         uplink = {
             'name': 'UplinkName',
-            'networkUris': ['/rest/ethernet-networks/134dcf5e-0d8e-441c-b00d-e1dd6a067188',
-                            '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
-                            '/rest/ethernet-networks/45gdo84i-6jgf-093b-gsd5-njkn543tb64l', ]
+            'networkUris': ['/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
+                            '/rest/ethernet-networks/45gdo84i-6jgf-093b-gsd5-njkn543tb64l']
         }
 
         uplink_to_update = {
-            'name': 'UplinkName',
             'networkUris': ['/rest/ethernet-networks/45gdo84i-6jgf-093b-gsd5-njkn543tb64l', ]
         }
 
-        mock_uplink_get.return_value = uplink
-        self._uplink_sets.remove_ethernet_networks(id, ethernet_to_remove)
+        self._ethernet_networks.data = {'name': 'eth1',
+                                        'uri': '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939'}
+        mock_ethernet_get.return_value = self._ethernet_networks
+
+        self._uplink_sets.data = uplink
+        self._uplink_sets.remove_ethernet_networks(ethernet_to_remove)
         mock_uplink_update.assert_called_once_with(uplink_to_update)
 
     @mock.patch.object(UplinkSets, 'update')
-    @mock.patch.object(UplinkSets, 'get')
-    def test_remove_a_list_of_ethernet_network_ids(self, mock_uplink_get, mock_uplink_update):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
-        ethernet_to_remove = [
-            '5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
-            '134dcf5e-0d8e-441c-b00d-e1dd6a067188',
-        ]
-        uplink = {
-            'name': 'UplinkName',
-            'networkUris': ['/rest/ethernet-networks/134dcf5e-0d8e-441c-b00d-e1dd6a067188',
-                            '/rest/ethernet-networks/5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
-                            '/rest/ethernet-networks/45gdo84i-6jgf-093b-gsd5-njkn543tb64l', ]
-        }
-
-        uplink_to_update = {
-            'name': 'UplinkName',
-            'networkUris': ['/rest/ethernet-networks/45gdo84i-6jgf-093b-gsd5-njkn543tb64l', ]
-        }
-        uplink_return = uplink_to_update.copy()
-
-        mock_uplink_update.return_value = uplink_return
-        mock_uplink_get.return_value = uplink
-
-        result = self._uplink_sets.remove_ethernet_networks(id, ethernet_to_remove)
-        mock_uplink_update.assert_called_once_with(uplink_to_update)
-        self.assertEqual(uplink_return, result)
-
-    @mock.patch.object(UplinkSets, 'update')
-    @mock.patch.object(UplinkSets, 'get')
+    @mock.patch.object(EthernetNetworks, 'get_by_name')
     def test_not_remove_ethernet_networks_already_not_associated(self, mock_uplink_get, mock_uplink_update):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
         ethernet_to_remove = [
-            'd34dcf5e-0d8e-441c-b00d-e1dd6a067188',
+            'eth1',
         ]
         uplink = {
             'name': 'UplinkName',
             'networkUris': ['/rest/ethernet-networks/45gdo84i-6jgf-093b-gsd5-njkn543tb64l', ]
         }
 
-        mock_uplink_get.return_value = uplink
-        result = self._uplink_sets.remove_ethernet_networks(id, ethernet_to_remove)
+        self._ethernet_networks.data = {'name': 'eth1',
+                                        'uri': '/rest/ethernet-networks/45gdo84i-6jgf-093b-gsd5-njk33'}
+        mock_uplink_get.return_value = self._ethernet_networks
+
+        self._uplink_sets.data = uplink
+        result = self._uplink_sets.remove_ethernet_networks(ethernet_to_remove)
+
         self.assertEqual(mock_uplink_update.call_count, 0)
         self.assertEqual(uplink, result)
 
-    @mock.patch.object(UplinkSets, 'get')
+    @mock.patch.object(EthernetNetworks, 'get_by_name')
     def test_set_ethernet_uris_with_invalid_operation(self, mock_uplink_get):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
         ethernet_to_add = [
-            '5f14bf27-f839-4e9f-9ec8-9f0e0b413939',
-            'd34dcf5e-0d8e-441c-b00d-e1dd6a067188',
+            'eth1',
         ]
 
         # Force a private call with invalid operation (aims to reach 100% coverage)
         self.assertRaises(ValueError,
                           self._uplink_sets._UplinkSets__set_ethernet_uris,
-                          id, ethernet_to_add, "invalid_operation")
+                          ethernet_to_add, "invalid_operation")
 
-        mock_uplink_get.assert_called_once_with(id)
+        mock_uplink_get.assert_called_once_with(ethernet_to_add[0])

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -441,9 +441,9 @@ class OneViewClientTest(unittest.TestCase):
         switches = self._oneview.switches
         self.assertEqual(switches, self._oneview.switches)
 
-    def test_lazy_loading_ethernet_networks(self):
+    def test_ethernet_networks(self):
         ethernet_networks = self._oneview.ethernet_networks
-        self.assertEqual(ethernet_networks, self._oneview.ethernet_networks)
+        self.assertNotEqual(ethernet_networks, self._oneview.ethernet_networks)
 
     def test_lazy_loading_server_hardware(self):
         server_hardware = self._oneview.server_hardware

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -441,9 +441,8 @@ class OneViewClientTest(unittest.TestCase):
         switches = self._oneview.switches
         self.assertEqual(switches, self._oneview.switches)
 
-    def test_ethernet_networks(self):
-        ethernet_networks = self._oneview.ethernet_networks
-        self.assertNotEqual(ethernet_networks, self._oneview.ethernet_networks)
+    def test_should_return_new_ethernet_networks(self):
+        self.assertNotEqual(self._oneview.ethernet_networks, self._oneview.ethernet_networks)
 
     def test_lazy_loading_server_hardware(self):
         server_hardware = self._oneview.server_hardware
@@ -690,15 +689,14 @@ class OneViewClientTest(unittest.TestCase):
         storage_volume_attachments = self._oneview.storage_volume_attachments
         self.assertEqual(storage_volume_attachments, self._oneview.storage_volume_attachments)
 
+    def test_should_return_new_uplink_sets_obj(self):
+        self.assertNotEqual(self._oneview.uplink_sets, self._oneview.uplink_sets)
+
     def test_uplink_sets_has_right_type(self):
         self.assertIsInstance(self._oneview.uplink_sets, UplinkSets)
 
     def test_uplink_sets_has_value(self):
         self.assertIsNotNone(self._oneview.uplink_sets)
-
-    def test_lazy_loading_uplink_sets(self):
-        copy_uplink_sets = self._oneview.uplink_sets
-        self.assertEqual(copy_uplink_sets, self._oneview.uplink_sets)
 
     def test_backups_has_right_type(self):
         self.assertIsInstance(self._oneview.backups, Backups)

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -441,7 +441,7 @@ class OneViewClientTest(unittest.TestCase):
         switches = self._oneview.switches
         self.assertEqual(switches, self._oneview.switches)
 
-    def test_should_return_new_ethernet_networks(self):
+    def test_should_return_new_ethernet_networks_obj(self):
         self.assertNotEqual(self._oneview.ethernet_networks, self._oneview.ethernet_networks)
 
     def test_lazy_loading_server_hardware(self):


### PR DESCRIPTION
### Description
Upgraded Ethernet and Uplinkset resources to support OneView API version 800

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
