### PR TITLE
Upgrade/800/fcoe networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ Resource data will be available with the resource object. This enhancement helps
 
 #### features supported with current release
 - Enclosure
-- FC Network
+- FC network
+- FCOE network
 
 # 4.8.0
 #### Notes

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -147,12 +147,12 @@
 |<sub>/rest/fc-networks/{id}</sub>                                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/fc-networks/{id}</sub>                                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **FCoE Networks**                                                                                                                             |
-|<sub>/rest/fcoe-networks</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
-|<sub>/rest/fcoe-networks</sub>                                                           | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
-|<sub>/rest/fcoe-networks/{id}</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
-|<sub>/rest/fcoe-networks/{id}</sub>                                                      | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark: |   :heavy_minus_sign:
-|<sub>/rest/fcoe-networks/{id}</sub>                                                      | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
-|<sub>/rest/fcoe-networks/{id}</sub>                                                      | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:
+|<sub>/rest/fcoe-networks</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fcoe-networks</sub>                                                           | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fcoe-networks/{id}</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fcoe-networks/{id}</sub>                                                      | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/fcoe-networks/{id}</sub>                                                      | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fcoe-networks/{id}</sub>                                                      | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Firmware Bundles**                                                                                                                          |
 |<sub>/rest/firmware-bundles</sub>                                                       | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Firmware Drivers**                                                                                                                          |

--- a/examples/fcoe_networks.py
+++ b/examples/fcoe_networks.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2012-2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2012-2019) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/fcoe_networks.py
+++ b/examples/fcoe_networks.py
@@ -33,6 +33,15 @@ config = {
         "password": "<password>"
     }
 }
+config = {
+    "ip": "10.50.4.100",
+    "credentials": {
+        "userName": "kattumun",
+        "password": "P@ssw0rd!"
+    },
+    "api_version": 800
+}
+
 
 options = {
     "name": "OneViewSDK Test FCoE Network",
@@ -40,75 +49,65 @@ options = {
     "connectionTemplateUri": None,
 }
 
-# FCoE Network ID to perform a get by ID
-fcoe_network_id = ""
-
 # Scope name to perform the patch operation
 scope_name = ""
 
 # Try load config from a file (if there is a config file)
 config = try_load_from_file(config)
-
 oneview_client = OneViewClient(config)
-
-# Create a FC Network
-fcoe_network = oneview_client.fcoe_networks.create(options)
-print("\nCreated fcoe-network '%s' successfully.\n  uri = '%s'" % (fcoe_network['name'], fcoe_network['uri']))
-
-# Find recently created network by name
-fcoe_network = oneview_client.fcoe_networks.get_by('name', 'OneViewSDK Test FCoE Network')[0]
-print("\nFound fcoe-network by name: '%s'.\n  uri = '%s'" % (fcoe_network['name'], fcoe_network['uri']))
-
-# Update autoLoginRedistribution from recently created network
-fcoe_network['status'] = 'Warning'
-fcoe_network = oneview_client.fcoe_networks.update(fcoe_network)
-print("\nUpdated fcoe-network '%s' successfully.\n  uri = '%s'" % (fcoe_network['name'], fcoe_network['uri']))
-print("  with attribute {'status': %s}" % fcoe_network['status'])
+fcoe_networks = oneview_client.fcoe_networks
 
 # Get all, with defaults
 print("\nGet all fcoe-networks")
-fcoe_nets = oneview_client.fcoe_networks.get_all()
+fcoe_nets = fcoe_networks.get_all()
 pprint(fcoe_nets)
 
 # Filter by name
 print("\nGet all fcoe-networks filtering by name")
-fcoe_nets_filtered = oneview_client.fcoe_networks.get_all(filter="\"'name'='OneViewSDK Test FCoE Network'\"")
+fcoe_nets_filtered = fcoe_networks.get_all(filter="\"'name'='OneViewSDK Test FCoE Network'\"")
 pprint(fcoe_nets_filtered)
 
 # Get all sorting by name descending
 print("\nGet all fcoe-networks sorting by name")
-fcoe_nets_sorted = oneview_client.fcoe_networks.get_all(sort='name:descending')
+fcoe_nets_sorted = fcoe_networks.get_all(sort='name:descending')
 pprint(fcoe_nets_sorted)
 
 # Get the first 10 records
 print("\nGet the first ten fcoe-networks")
-fcoe_nets_limited = oneview_client.fcoe_networks.get_all(0, 10)
+fcoe_nets_limited = fcoe_networks.get_all(0, 10)
 pprint(fcoe_nets_limited)
 
-# Get by ID
-if fcoe_network_id:
-    try:
-        print("\nGet a fcoe-network by id")
-        fcoe_nets_byid = oneview_client.fcoe_networks.get(fcoe_network_id)
-        pprint(fcoe_nets_byid)
-    except HPOneViewException as e:
-        print(e.msg)
+#Get by name
+fcoe_network = fcoe_networks.get_by_name(options['name'])
+if fcoe_network:
+    print("\nGot fcoe-network by name uri={}".format(fcoe_network.data['uri']))
+else:
+    # Create a FC Network
+    fcoe_network = fcoe_networks.create(options)
+    print("\nCreated fcoe-network '%s' successfully.\n  uri = '%s'" % (fcoe_network.data['name'], fcoe_network.data['uri']))
+
+# Update autoLoginRedistribution from recently created network
+resource = fcoe_network.data.copy()
+resource['status'] = 'Warning'
+resource['name'] = "{}-Renamed".format(options["name"])
+fcoe_network.update(resource)
+print("\nUpdated fcoe-network '%s' successfully.\n  uri = '%s'" % (fcoe_network.data['name'], fcoe_network.data['uri']))
+print("  with attribute {'status': %s}" % fcoe_network.data['status'])
 
 # Get by Uri
 print("\nGet a fcoe-network by uri")
-fcoe_nets_by_uri = oneview_client.fcoe_networks.get(fcoe_network['uri'])
-pprint(fcoe_nets_by_uri)
+fcoe_nets_by_uri = fcoe_networks.get_by_uri(fcoe_network.data['uri'])
+pprint(fcoe_nets_by_uri.data)
 
 # Adds ethernet to scope defined
 if scope_name:
     print("\nGet scope then add the network to it")
     scope = oneview_client.scopes.get_by_name(scope_name)
-    fcoe_with_scope = oneview_client.fcoe_networks.patch(fcoe_network['uri'],
-                                                         'replace',
-                                                         '/scopeUris',
-                                                         [scope['uri']])
-    pprint(fcoe_with_scope)
+    fcoe_with_scope = fcoe_network.patch('replace',
+                                         '/scopeUris',
+                                         [scope['uri']])
+    pprint(fcoe_with_scope.data)
 
 # Delete the created network
-oneview_client.fcoe_networks.delete(fcoe_network)
+fcoe_network.delete()
 print("\nSuccessfully deleted fcoe-network")

--- a/examples/fcoe_networks.py
+++ b/examples/fcoe_networks.py
@@ -22,7 +22,6 @@
 ###
 
 from pprint import pprint
-from hpOneView.exceptions import HPOneViewException
 from hpOneView.oneview_client import OneViewClient
 from config_loader import try_load_from_file
 
@@ -33,15 +32,6 @@ config = {
         "password": "<password>"
     }
 }
-config = {
-    "ip": "10.50.4.100",
-    "credentials": {
-        "userName": "kattumun",
-        "password": "P@ssw0rd!"
-    },
-    "api_version": 800
-}
-
 
 options = {
     "name": "OneViewSDK Test FCoE Network",
@@ -77,7 +67,7 @@ print("\nGet the first ten fcoe-networks")
 fcoe_nets_limited = fcoe_networks.get_all(0, 10)
 pprint(fcoe_nets_limited)
 
-#Get by name
+# Get by name
 fcoe_network = fcoe_networks.get_by_name(options['name'])
 if fcoe_network:
     print("\nGot fcoe-network by name uri={}".format(fcoe_network.data['uri']))

--- a/hpOneView/resources/networking/fcoe_networks.py
+++ b/hpOneView/resources/networking/fcoe_networks.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2012-2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2012-2019) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/hpOneView/resources/networking/fcoe_networks.py
+++ b/hpOneView/resources/networking/fcoe_networks.py
@@ -31,10 +31,10 @@ from future import standard_library
 standard_library.install_aliases()
 
 
-from hpOneView.resources.resource import ResourceClient
+from hpOneView.resources.resource import Resource, ResourcePatchMixin
 
 
-class FcoeNetworks(object):
+class FcoeNetworks(ResourcePatchMixin, Resource):
     """
     FCoE Networks API client.
 
@@ -45,125 +45,9 @@ class FcoeNetworks(object):
         '200': {"type": "fcoe-network"},
         '300': {"type": "fcoe-networkV300"},
         '500': {"type": "fcoe-networkV300"},
-        '600': {"type": "fcoe-networkV4"}
+        '600': {"type": "fcoe-networkV4"},
+        '800': {"type": "fcoe-networkV4"},
     }
 
-    def __init__(self, con):
-        self._connection = con
-        self._client = ResourceClient(con, self.URI)
-
-    def get_all(self, start=0, count=-1, filter='', sort=''):
-        """
-        Gets a paginated collection of FCoE networks. The collection is based on optional sorting and filtering, and
-        constrained by start and count parameters.
-
-        Args:
-            start:
-                The first item to return, using 0-based indexing.
-                If not specified, the default is 0 - start with the first available item.
-            count:
-                The number of resources to return. A count of -1 requests all items.
-                The actual number of items in the response might differ from the requested
-                count if the sum of start and count exceeds the total number of items.
-            filter (list or str):
-                A general filter/query string to narrow the list of items returned. The
-                default is no filter; all resources are returned.
-            sort:
-                The sort order of the returned data set. By default, the sort order is based
-                on create time with the oldest entry first.
-
-        Returns:
-            list: A list of FCoE networks.
-        """
-        return self._client.get_all(start, count, filter=filter, sort=sort)
-
-    def delete(self, resource, force=False, timeout=-1):
-        """
-        Deletes a FCoE network.
-
-        Args:
-            resource(str, dict):
-                Accept either the resource id  or the entire resource.
-            force:
-                 If set to true, the operation completes despite any problems with
-                 network connectivity or errors on the resource itself. The default is false.
-            timeout: Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView; it just stops waiting for its completion.
-
-        Returns:
-            bool: Indicates if the resource was successfully deleted.
-        """
-        return self._client.delete(resource, force=force, timeout=timeout)
-
-    def get(self, id_or_uri):
-        """
-        Gets a FCoE network.
-
-        Args:
-            id_or_uri: ID or URI of FCoE network.
-
-        Returns:
-            dict: FCoE network.
-        """
-        return self._client.get(id_or_uri)
-
-    def create(self, resource, timeout=-1):
-        """
-        Creates FCoE network.
-
-        Args:
-            resource (dict): Object to create.
-            timeout: Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView; it just stops waiting for its completion.
-
-        Returns: Created resource.
-        """
-        return self._client.create(resource, timeout=timeout, default_values=self.DEFAULT_VALUES)
-
-    def update(self, resource, timeout=-1):
-        """
-        Updates a FCoE network.
-
-        Args:
-            resource (dict): Resource to update.
-            timeout: Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView; it just stops waiting for its completion.
-
-        Returns:
-            dict: Updated resource.
-        """
-        return self._client.update(resource, timeout=timeout, default_values=self.DEFAULT_VALUES)
-
-    def get_by(self, field, value):
-        """
-        Gets all FCoE networks that match the filter.
-
-        The search is case-insensitive.
-
-        Args:
-            field: Field name to filter.
-            value: Value to filter.
-
-        Returns:
-            list: A list of FCoE networks.
-        """
-        return self._client.get_by(field, value)
-
-    def patch(self, id_or_uri, operation, path, value, timeout=-1):
-        """
-        Uses the PATCH to update the given resource.
-
-        Only one operation can be performed in each PATCH call.
-
-        Args:
-            id_or_uri: Can be either the resource ID or the resource URI.
-            operation: Patch operation
-            path: Path
-            value: Value
-            timeout: Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView; it just stops waiting for its completion.
-
-        Returns:
-            dict: Updated resource.
-        """
-        return self._client.patch(id_or_uri, operation, path, value, timeout=timeout)
+    def __init__(self, connection, data=None):
+        super(FcoeNetworks, self).__init__(connection, data)

--- a/tests/unit/resources/networking/test_fcoe_networks.py
+++ b/tests/unit/resources/networking/test_fcoe_networks.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2012-2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2012-2019) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the 'Software'), to deal
@@ -27,7 +27,7 @@ import mock
 
 from hpOneView.connection import connection
 from hpOneView.resources.networking.fcoe_networks import FcoeNetworks
-from hpOneView.resources.resource import ResourceClient
+from hpOneView.resources.resource import Resource
 
 
 class FcoeNetworksTest(TestCase):
@@ -36,7 +36,7 @@ class FcoeNetworksTest(TestCase):
         self.connection = connection(self.host)
         self._fcoe_networks = FcoeNetworks(self.connection)
 
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(Resource, 'get_all')
     def test_get_all_called_once(self, mock_get_all):
         filter = 'name=TestName'
         sort = 'name:ascending'
@@ -45,7 +45,7 @@ class FcoeNetworksTest(TestCase):
 
         mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort)
 
-    @mock.patch.object(ResourceClient, 'create')
+    @mock.patch.object(Resource, 'create')
     def test_create(self, mock_create):
         resource = {
             'name': 'OneViewSDK Test FCoE Network',
@@ -57,7 +57,7 @@ class FcoeNetworksTest(TestCase):
 
         mock_create.assert_called_once_with(resource, timeout=-1, default_values=self._fcoe_networks.DEFAULT_VALUES)
 
-    @mock.patch.object(ResourceClient, 'update')
+    @mock.patch.object(Resource, 'update')
     def test_update(self, mock_update):
         resource = {
             'name': 'vsan1',
@@ -72,33 +72,33 @@ class FcoeNetworksTest(TestCase):
         mock_update.assert_called_once_with(resource_rest_call, timeout=12,
                                             default_values=self._fcoe_networks.DEFAULT_VALUES)
 
-    @mock.patch.object(ResourceClient, 'delete')
+    @mock.patch.object(Resource, 'delete')
     def test_delete_called_once(self, mock_delete):
         id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
         self._fcoe_networks.delete(id, force=False, timeout=50)
 
         mock_delete.assert_called_once_with(id, force=False, timeout=50)
 
-    @mock.patch.object(ResourceClient, 'get_by')
+    @mock.patch.object(Resource, 'get_by')
     def test_get_by_called_once(self, mock_get_by):
         self._fcoe_networks.get_by('name', 'OneViewSDK Test FCoE Network')
 
         mock_get_by.assert_called_once_with('name', 'OneViewSDK Test FCoE Network')
 
-    @mock.patch.object(ResourceClient, 'get')
+    @mock.patch.object(Resource, 'get')
     def test_get_called_once(self, mock_get):
         self._fcoe_networks.get('3518be0e-17c1-4189-8f81-83f3724f6155')
 
         mock_get.assert_called_once_with('3518be0e-17c1-4189-8f81-83f3724f6155')
 
-    @mock.patch.object(ResourceClient, 'get')
+    @mock.patch.object(Resource, 'get')
     def test_get_with_uri_called_once(self, mock_get):
         uri = '/rest/fcoe-networks/3518be0e-17c1-4189-8f81-83f3724f6155'
         self._fcoe_networks.get(uri)
 
         mock_get.assert_called_once_with(uri)
 
-    @mock.patch.object(ResourceClient, 'patch')
+    @mock.patch.object(Resource, 'patch')
     def test_patch_should_use_user_defined_values(self, mock_patch):
         mock_patch.return_value = {}
 

--- a/tests/unit/resources/networking/test_fcoe_networks.py
+++ b/tests/unit/resources/networking/test_fcoe_networks.py
@@ -35,7 +35,7 @@ class FcoeNetworksTest(TestCase):
         self.host = '127.0.0.1'
         self.connection = connection(self.host)
         self._fcoe_networks = FcoeNetworks(self.connection)
-        self.uri = "/rest/fcoe-networks/"
+        self.uri = "/rest/fcoe-networks/3518be0e-17c1-4189-8f81-83f3724f6155"
         self._fcoe_networks.data = {"uri": self.uri}
 
     @mock.patch.object(ResourceHelper, 'get_all')
@@ -69,11 +69,11 @@ class FcoeNetworksTest(TestCase):
             'type': 'fcoe-networkV2',
         }
         resource_rest_call = resource.copy()
+        resource_rest_call.update(self._fcoe_networks.data)
         mock_update.return_value = {}
 
         self._fcoe_networks.update(resource, timeout=12)
-        mock_update.assert_called_once_with(resource_rest_call, timeout=12,
-                                            default_values=self._fcoe_networks.DEFAULT_VALUES)
+        mock_update.assert_called_once_with(resource_rest_call, self.uri, False, 12, None)
 
     @mock.patch.object(ResourceHelper, 'delete')
     def test_delete_called_once(self, mock_delete):


### PR DESCRIPTION
### Description
Upgraded FCOE networks to support OneView API version 800

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
