### PR TITLE
Upgrade/800/internal link sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Resource data will be available with the resource object. This enhancement helps
 - Enclosure
 - FC network
 - Interconnect type
+- Internal link set
 
 # 4.8.0
 #### Notes

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -231,8 +231,8 @@
 |<sub>/rest/interconnects/{id}/update-ports</sub>                                         | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/interconnects/{id}/nameServers</sub>                                          | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Internal Link Sets**                                                                                                                       |
-|<sub>/rest/internal-link-sets</sub>                                                      | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:  |
-|<sub>/rest/internal-link-sets/{id}</sub>                                                 | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:  |
+|<sub>/rest/internal-link-sets</sub>                                                      | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:  | :white_check_mark:  |
+|<sub>/rest/internal-link-sets/{id}</sub>                                                 | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:  | :white_check_mark:  |
 |     **Labels**                                                                                                                                   |
 |<sub>/rest/labels</sub>                                                                  | GET      | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/labels/resources</sub>                                                        | POST     | :white_check_mark:   | :white_check_mark:   |

--- a/examples/internal_link_sets.py
+++ b/examples/internal_link_sets.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2012-2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2012-2019) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,29 +28,24 @@ from config_loader import try_load_from_file
 config = {
     "ip": "<oneview_ip>",
     "credentials": {
-        "userName": "<oneview_administrator_name>",
-        "password": "<oneview_administrator_password>",
+        "userName": "<username>",
+        "password": "<password>",
     }
 }
 
 # Try load config from a file (if there is a config file)
 config = try_load_from_file(config)
-
 oneview_client = OneViewClient(config)
+internal_link_sets = oneview_client.internal_link_sets
 
 # Get all, with defaults
 print("Get all internal-link-sets")
-internal_links = oneview_client.internal_link_sets.get_all()
+internal_links = internal_link_sets.get_all()
 pprint(internal_links)
 
 internal_link_set_uri = internal_links[0]['uri']
 internal_link_set_name = internal_links[0]['name']
 
-# Get by Uri
-print("\nGet a internal-link-set by uri")
-internal_links_by_uri = oneview_client.internal_link_sets.get(internal_link_set_uri)
-pprint(internal_links_by_uri)
-
 # Find by name
-internal_links_by_name = oneview_client.internal_link_sets.get_by('name', internal_link_set_name)
-print("\nFound the internal-link-sets by name: '{}':".format(internal_links_by_name[0]['name']))
+internal_links_by_name = internal_link_sets.get_by_name(internal_links[0]["name"])
+print("\nFound the internal-link-sets by name: '{}':".format(internal_links_by_name.data["name"]))

--- a/hpOneView/resources/networking/internal_link_sets.py
+++ b/hpOneView/resources/networking/internal_link_sets.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2012-2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2012-2019) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,10 +31,10 @@ from future import standard_library
 standard_library.install_aliases()
 
 
-from hpOneView.resources.resource import ResourceClient
+from hpOneView.resources.resource import Resource
 
 
-class InternalLinkSets(object):
+class InternalLinkSets(Resource):
     """
     Internal Link Sets API client.
 
@@ -45,9 +45,8 @@ class InternalLinkSets(object):
 
     URI = '/rest/internal-link-sets'
 
-    def __init__(self, con):
-        self._connection = con
-        self._client = ResourceClient(con, self.URI)
+    def __init__(self, connection, data=None):
+        super(InternalLinkSets, self).__init__(connection, data)
 
     def get_all(self, start=0, count=-1, filter='', query='', sort='', view='', fields=''):
         """
@@ -81,33 +80,5 @@ class InternalLinkSets(object):
         Returns:
             list:  Internal Link Set Collection.
         """
-        return self._client.get_all(start=start, count=count, filter=filter, query=query, sort=sort, view=view,
-                                    fields=fields)
-
-    def get(self, id_or_uri):
-        """
-        Gets a specific internal-link-set resource.
-
-        Args:
-            id_or_uri: ID or URI of the Internal Link Set resource.
-
-        Returns:
-            dict: Internal Link Set.
-        """
-        return self._client.get(id_or_uri)
-
-    def get_by(self, field, value):
-        """
-        Gets all internal-link-sets that match the filter.
-        The search is case-insensitive.
-
-        Args:
-            field: field name to filter
-            value: value to filter
-
-        Returns:
-            list: A list of Internal Link Sets.
-        """
-        links = self._client.get_all()
-        result = [x for x in links if x[field] == value]
-        return result if result else []
+        return self._helper.get_all(start=start, count=count, filter=filter,
+                                    query=query, sort=sort, view=view, fields=fields)

--- a/tests/unit/resources/networking/test_internal_link_sets.py
+++ b/tests/unit/resources/networking/test_internal_link_sets.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2012-2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2012-2019) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the 'Software'), to deal
@@ -27,7 +27,7 @@ import mock
 
 from hpOneView.connection import connection
 from hpOneView.resources.networking.internal_link_sets import InternalLinkSets
-from hpOneView.resources.resource import ResourceClient
+from hpOneView.resources.resource import ResourceHelper
 
 INTERNAL_LINK_SETS = [
     {'name': 'OneViewSDK Test Internal Link Set'},
@@ -43,7 +43,7 @@ class InternalLinkSetsTest(TestCase):
         self.connection = connection(self.host)
         self._client = InternalLinkSets(self.connection)
 
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(ResourceHelper, 'get_all')
     def test_get_all_called_once(self, mock_get_all):
         filter = 'name=TestName'
         sort = 'name:ascending'
@@ -56,12 +56,12 @@ class InternalLinkSetsTest(TestCase):
         mock_get_all.assert_called_once_with(start=2, count=500, filter=filter, sort=sort, query=query, fields=fields,
                                              view=view)
 
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(ResourceHelper, 'get_all')
     def test_get_all_without_parameters(self, mock_get_all):
         self._client.get_all()
         mock_get_all.assert_called_once_with(start=0, count=-1, filter='', sort='', query='', fields='', view='')
 
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(ResourceHelper, 'get_all')
     def test_get_by_called_once(self, mock_get_all):
         mock_get_all.return_value = INTERNAL_LINK_SETS
         expected_result = [
@@ -73,7 +73,7 @@ class InternalLinkSetsTest(TestCase):
 
         self.assertEqual(result, expected_result)
 
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(ResourceHelper, 'get_all')
     def test_get_by_should_return_empty_list_when_not_match(self, mock_get_all):
         mock_get_all.return_value = INTERNAL_LINK_SETS
         expected_result = []
@@ -81,16 +81,3 @@ class InternalLinkSetsTest(TestCase):
         result = self._client.get_by('name', 'Testing')
 
         self.assertEqual(result, expected_result)
-
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_called_once(self, mock_get):
-        self._client.get('3518be0e-17c1-4189-8f81-83f3724f6155')
-
-        mock_get.assert_called_once_with('3518be0e-17c1-4189-8f81-83f3724f6155')
-
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_with_uri_called_once(self, mock_get):
-        uri = '/rest/internal-link-sets/3518be0e-17c1-4189-8f81-83f3724f6155'
-        self._client.get(uri)
-
-        mock_get.assert_called_once_with(uri)


### PR DESCRIPTION
### Description
Upgraded internal link set resource to support OneView API version 800


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
