### PR TITLE
Upgrade/800/logical interconnect groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Resource data will be available with the resource object. This enhancement helps
 - Enclosure
 - FC network
 - Interconnect type
+- Logical interconnect group
 
 # 4.8.0
 #### Notes

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -268,7 +268,7 @@
 |<sub>/rest/logical-interconnect-groups/defaultSettings</sub>                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :heavy_minus_sign:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
 |<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/logical-interconnect-groups/{id}/settings</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Logical Interconnects**                                                                                                                     |

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -263,14 +263,14 @@
 |<sub>/rest/logical-enclosures/{id}/support-dumps</sub>                                   | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/logical-enclosures/{id}/updateFromGroup</sub>                                 | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Logical Interconnect Groups**                                                                                                               |
-|<sub>/rest/logical-interconnect-groups</sub>                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups</sub>                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/defaultSettings</sub>                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :heavy_minus_sign:   |
-|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/{id}/settings</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups</sub>                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups</sub>                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/defaultSettings</sub>                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | PATCH    | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :heavy_minus_sign:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/{id}/settings</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Logical Interconnects**                                                                                                                     |
 |<sub>/rest/logical-interconnects</sub>                                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/logical-interconnects/locations/interconnects</sub>                           | POST     | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :white_check_mark:   |

--- a/examples/logical_interconnect_groups.py
+++ b/examples/logical_interconnect_groups.py
@@ -39,16 +39,19 @@ config = {
 config = try_load_from_file(config)
 oneview_client = OneViewClient(config)
 logical_interconnect_groups = oneview_client.logical_interconnect_groups
+interconnect_types = oneview_client.interconnect_types
 
 # Define the scope name to add the logical interconnect group to it
 scope_name = ""
 
-# Get the interconnect type named 'HP VC FlexFabric 10Gb/24-Port Module' and using the uri in the values for the fields
+interconnect_type_name = "Synergy 10Gb Interconnect Link Module"
+# Get the interconnect type by name and using the uri in the values for the fields
 # "permittedInterconnectTypeUri" and create a Logical Interconnect Group.
 # Note: If this type does not exist, select another name
-data = oneview_client.interconnect_types.get_all()
-pprint(data)
-interconnect_type = oneview_client.interconnect_types.get_by('name', 'Synergy 10Gb Interconnect Link Module')[0]['uri']
+interconnect_type = oneview_client.interconnect_types.get_by_name(interconnect_type_name)
+if interconnect_type:
+    pprint(interconnect_type.data)
+    interconnect_type_url = interconnect_type.data["uri"]
 
 options = {
     "category": None,

--- a/examples/logical_interconnect_groups.py
+++ b/examples/logical_interconnect_groups.py
@@ -25,7 +25,6 @@
 from pprint import pprint
 
 from config_loader import try_load_from_file
-from hpOneView.exceptions import HPOneViewException
 from hpOneView.oneview_client import OneViewClient
 
 config = {
@@ -35,14 +34,7 @@ config = {
         "password": "<password>"
     }
 }
-config = {
-    "ip": "10.50.9.43",
-    "credentials": {
-        "userName": "administrator",
-        "password": "ecosystem"
-    },
-    "api_version": 800
-}
+
 # Try load config from a file (if there is a config file)
 config = try_load_from_file(config)
 oneview_client = OneViewClient(config)
@@ -65,7 +57,7 @@ options = {
     "eTag": None,
     "uplinkSets": [],
     "modified": None,
-    "name": "SYN-LIG",
+    "name": "OneView Test Logical Interconnect Group",
     "state": "Active",
     "status": None,
     "enclosureType": "C7000",
@@ -235,7 +227,7 @@ if oneview_client.api_version >= 600:
     else:
         print("No Logical Interconnect Group found.")
 
-#Get logical interconnect group by name
+# Get logical interconnect group by name
 lig = logical_interconnect_groups.get_by_name(options["name"])
 if not lig:
     # Create a logical interconnect group

--- a/examples/logical_interconnect_groups.py
+++ b/examples/logical_interconnect_groups.py
@@ -80,7 +80,7 @@ options = {
                         }
                     ]
                 },
-                "permittedInterconnectTypeUri": interconnect_type
+                "permittedInterconnectTypeUri": interconnect_type_url
             },
             {
                 "logicalDownlinkUri": None,

--- a/examples/logical_interconnect_groups.py
+++ b/examples/logical_interconnect_groups.py
@@ -35,11 +35,18 @@ config = {
         "password": "<password>"
     }
 }
-
+config = {
+    "ip": "10.50.9.42",
+    "credentials": {
+        "userName": "administrator",
+        "password": "ecosystem"
+    },
+    "api_version": 800
+}
 # Try load config from a file (if there is a config file)
 config = try_load_from_file(config)
-
 oneview_client = OneViewClient(config)
+logical_interconnect_groups = oneview_client.logical_interconnect_groups
 
 # Define the scope name to add the logical interconnect group to it
 scope_name = ""
@@ -47,7 +54,9 @@ scope_name = ""
 # Get the interconnect type named 'HP VC FlexFabric 10Gb/24-Port Module' and using the uri in the values for the fields
 # "permittedInterconnectTypeUri" and create a Logical Interconnect Group.
 # Note: If this type does not exist, select another name
-interconnect_type = oneview_client.interconnect_types.get_by('name', 'HP VC FlexFabric 10Gb/24-Port Module')[0]['uri']
+data = oneview_client.interconnect_types.get_all()
+pprint(data)
+interconnect_type = oneview_client.interconnect_types.get_by('name', 'Synergy 10Gb Interconnect Link Module')[0]['uri']
 
 options = {
     "category": None,
@@ -193,72 +202,32 @@ options = {
     }
 }
 
-# Create a logical interconnect group
-print("Create a logical interconnect group")
-created_lig = oneview_client.logical_interconnect_groups.create(options)
-pprint(created_lig)
-
-# Get the first 10 records, sorting by name descending, filtering by name
-print("Get the first Logical Interconnect Groups, sorting by name descending, filtering by name")
-ligs = oneview_client.logical_interconnect_groups.get_all(
-    0, 10, sort='name:descending', filter="\"'name'='OneView Test Logical Interconnect Group'\"")
-pprint(ligs)
-
-# Get Logical Interconnect Group by property
-lig = oneview_client.logical_interconnect_groups.get_by('name', 'OneView Test Logical Interconnect Group')[0]
-print("Found lig by name: '%s'.\n  uri = '%s'" % (lig['name'], lig['uri']))
-
-# Update a logical interconnect group
-print("Update a logical interconnect group")
-lig_to_update = created_lig.copy()
-lig_to_update["name"] = "Renamed Logical Interconnect Group"
-updated_lig = oneview_client.logical_interconnect_groups.update(lig_to_update)
-pprint(updated_lig)
-
 # Get all, with defaults
 print("Get all Logical Interconnect Groups")
-ligs = oneview_client.logical_interconnect_groups.get_all()
+ligs = logical_interconnect_groups.get_all()
 pprint(ligs)
-
-# Get by Id
-try:
-    print("Get a Logical Interconnect Group by id")
-    lig_byid = oneview_client.logical_interconnect_groups.get('f0a0a113-ec97-41b4-83ce-d7c92b900e7c')
-    pprint(lig_byid)
-except HPOneViewException as e:
-    print(e.msg)
 
 # Get by uri
 try:
     print("Get a Logical Interconnect Group by uri")
-    lig_byuri = oneview_client.logical_interconnect_groups.get(created_lig["uri"])
-    pprint(lig_byuri)
+    lig_byuri = logical_interconnect_groups.get_by_uri(ligs[0]["uri"])
+    pprint(lig_byuri.data)
 except HPOneViewException as e:
     print(e.msg)
 
-# Performs a patch operation
-scope = oneview_client.scopes.get_by_name(scope_name)
-if scope:
-    print("\nPatches the logical interconnect group adding one scope to it")
-    updated_lig = oneview_client.logical_interconnect_groups.patch(updated_lig['uri'],
-                                                                   'replace',
-                                                                   '/scopeUris',
-                                                                   [scope['uri']])
-    pprint(updated_lig)
+# Get the first 10 records, sorting by name descending, filtering by name
+print("Get the first Logical Interconnect Groups, sorting by name descending, filtering by name")
+ligs = logical_interconnect_groups.get_all(
+    0, 10, sort='name:descending', filter="\"'name'='OneView Test Logical Interconnect Group'\"")
+pprint(ligs)
 
-# Get default settings
-print("Get the default interconnect settings for a logical interconnect group")
-lig_default_settings = oneview_client.logical_interconnect_groups.get_default_settings()
-pprint(lig_default_settings)
-
-# Get settings
-print("Gets the interconnect settings for a logical interconnect group")
-lig_settings = oneview_client.logical_interconnect_groups.get_settings(created_lig["uri"])
-pprint(lig_settings)
+# Get Logical Interconnect Group by property
+lig = logical_interconnect_groups.get_by('name', 'SYN-LIG')[0]
+print("Found lig by name: '%s'.\n  uri = '%s'" % (lig['name'], lig['uri']))
 
 # Get Logical Interconnect Group by scope_uris
 if oneview_client.api_version >= 600:
-    lig_by_scope_uris = oneview_client.logical_interconnect_groups.get_all(scope_uris="\"'/rest/scopes/3bb0c754-fd38-45af-be8a-4d4419de06e9'\"")
+    lig_by_scope_uris = logical_interconnect_groups.get_all(scope_uris="\"'/rest/scopes/3bb0c754-fd38-45af-be8a-4d4419de06e9'\"")
     if len(lig_by_scope_uris) > 0:
         print("Found %d Logical Interconnect Groups" % (len(lig_by_scope_uris)))
         i = 0
@@ -269,7 +238,41 @@ if oneview_client.api_version >= 600:
     else:
         print("No Logical Interconnect Group found.")
 
+#Get logical interconnect group by name
+lig = logical_interconnect_groups.get_by_name(options["name"])
+if not lig:
+    # Create a logical interconnect group
+    print("Create a logical interconnect group")
+    lig = logical_interconnect_groups.create(options)
+    pprint(lig.data)
+
+# Update a logical interconnect group
+print("Update a logical interconnect group")
+lig_to_update = lig.data.copy()
+lig_to_update["name"] = "Renamed Logical Interconnect Group"
+lig.update(lig_to_update)
+pprint(lig.data)
+
+# Performs a patch operation
+scope = oneview_client.scopes.get_by_name(scope_name)
+if scope:
+    print("\nPatches the logical interconnect group adding one scope to it")
+    updated_lig = lig.patch('replace',
+                            '/scopeUris',
+                            [scope['uri']])
+    pprint(updated_lig.data)
+
+# Get default settings
+print("Get the default interconnect settings for a logical interconnect group")
+lig_default_settings = lig.get_default_settings()
+pprint(lig_default_settings)
+
+# Get settings
+print("Gets the interconnect settings for a logical interconnect group")
+lig_settings = lig.get_settings()
+pprint(lig_settings)
+
 # Delete a logical interconnect group
 print("Delete the created logical interconnect group")
-oneview_client.logical_interconnect_groups.delete(updated_lig)
+lig.delete()
 print("Successfully deleted logical interconnect group")

--- a/examples/logical_interconnect_groups.py
+++ b/examples/logical_interconnect_groups.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2012-2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2012-2019) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -36,7 +36,7 @@ config = {
     }
 }
 config = {
-    "ip": "10.50.9.42",
+    "ip": "10.50.9.43",
     "credentials": {
         "userName": "administrator",
         "password": "ecosystem"
@@ -65,7 +65,7 @@ options = {
     "eTag": None,
     "uplinkSets": [],
     "modified": None,
-    "name": "OneView Test Logical Interconnect Group",
+    "name": "SYN-LIG",
     "state": "Active",
     "status": None,
     "enclosureType": "C7000",
@@ -208,12 +208,9 @@ ligs = logical_interconnect_groups.get_all()
 pprint(ligs)
 
 # Get by uri
-try:
-    print("Get a Logical Interconnect Group by uri")
-    lig_byuri = logical_interconnect_groups.get_by_uri(ligs[0]["uri"])
-    pprint(lig_byuri.data)
-except HPOneViewException as e:
-    print(e.msg)
+print("Get a Logical Interconnect Group by uri")
+lig_byuri = logical_interconnect_groups.get_by_uri(ligs[0]["uri"])
+pprint(lig_byuri.data)
 
 # Get the first 10 records, sorting by name descending, filtering by name
 print("Get the first Logical Interconnect Groups, sorting by name descending, filtering by name")

--- a/hpOneView/resources/networking/logical_interconnect_groups.py
+++ b/hpOneView/resources/networking/logical_interconnect_groups.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2012-2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2012-2019) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,10 +31,10 @@ from future import standard_library
 standard_library.install_aliases()
 
 
-from hpOneView.resources.resource import ResourceClient
+from hpOneView.resources.resource import Resource, ResourcePatchMixin
 
 
-class LogicalInterconnectGroups(object):
+class LogicalInterconnectGroups(ResourcePatchMixin, Resource):
     """
     Logical Interconnect Groups API client.
 
@@ -45,12 +45,12 @@ class LogicalInterconnectGroups(object):
         '200': {"type": "logical-interconnect-groupV3"},
         '300': {"type": "logical-interconnect-groupV300"},
         '500': {"type": "logical-interconnect-groupV300"},
-        '600': {"type": "logical-interconnect-groupV4"}
+        '600': {"type": "logical-interconnect-groupV4"},
+        '800': {"type": "logical-interconnect-groupV5"}
     }
 
-    def __init__(self, con):
-        self._connection = con
-        self._client = ResourceClient(con, self.URI)
+    def __init__(self, connection, data=None):
+        super(LogicalInterconnectGroups, self).__init__(connection, data)
 
     def get_all(self, start=0, count=-1, filter='', sort='', scope_uris=''):
         """
@@ -78,19 +78,7 @@ class LogicalInterconnectGroups(object):
         Returns:
             list: A list of logical interconnect groups.
         """
-        return self._client.get_all(start, count, filter=filter, sort=sort, scope_uris=scope_uris)
-
-    def get(self, id_or_uri):
-        """
-        Gets a logical interconnect group by ID or by URI.
-
-        Args:
-            id_or_uri: Can be either the logical interconnect group id or the logical interconnect group uri.
-
-        Returns:
-            dict: The logical interconnect group.
-        """
-        return self._client.get(id_or_uri)
+        return self._helper.get_all(start, count, filter=filter, sort=sort, scope_uris=scope_uris)
 
     def get_default_settings(self):
         """
@@ -100,101 +88,14 @@ class LogicalInterconnectGroups(object):
             dict: Interconnect Settings.
         """
         uri = self.URI + "/defaultSettings"
-        return self._client.get(uri)
+        return self._helper.do_get(uri)
 
-    def get_settings(self, id_or_uri):
+    def get_settings(self):
         """
         Gets the interconnect settings for a logical interconnect group.
-
-        Args:
-            id_or_uri: Can be either the logical interconnect group id or the logical interconnect group uri.
 
         Returns:
             dict: Interconnect Settings.
         """
-        uri = self._client.build_uri(id_or_uri) + "/settings"
-        return self._client.get(uri)
-
-    def create(self, resource, timeout=-1):
-        """
-        Creates a logical interconnect group.
-
-        Args:
-            resource (dict): Object to create
-            timeout:
-                Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView; it just stops waiting for its completion.
-
-        Returns:
-            dict: Created logical interconnect group.
-
-        """
-        return self._client.create(resource, timeout=timeout, default_values=self.DEFAULT_VALUES)
-
-    def update(self, resource, timeout=-1):
-        """
-        Updates a logical interconnect group.
-
-        Args:
-            resource (dict): Object to update
-            timeout:
-                Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView; it just stops waiting for its completion.
-
-        Returns:
-            dict: Updated logical interconnect group.
-
-        """
-        return self._client.update(resource, timeout=timeout, default_values=self.DEFAULT_VALUES)
-
-    def delete(self, resource, force=False, timeout=-1):
-        """
-        Deletes a logical interconnect group.
-
-        Args:
-            resource (dict): Object to delete.
-            force (bool):
-                 If set to true, the operation completes despite any problems with
-                 network connectivity or errors on the resource itself. The default is false.
-            timeout:
-                Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView; it just stops waiting for its completion.
-
-        Returns:
-            bool: Indicates if the resource was successfully deleted.
-        """
-        return self._client.delete(resource, force=force, timeout=timeout)
-
-    def get_by(self, field, value):
-        """
-        Gets all Logical interconnect groups that match the filter.
-
-        The search is case-insensitive.
-
-        Args:
-            field: Field name to filter.
-            value: Value to filter.
-
-        Returns:
-            list: A list of Logical interconnect groups.
-        """
-        return self._client.get_by(field, value)
-
-    def patch(self, id_or_uri, operation, path, value, timeout=-1):
-        """
-        Uses the PATCH to update a resource for a given logical interconnect group.
-
-        Only one operation can be performed in each PATCH call.
-
-        Args:
-            id_or_uri: Can be either the resource ID or the resource URI.
-            operation: Patch operation
-            path: Path
-            value: Value
-            timeout: Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView; it just stops waiting for its completion.
-
-        Returns:
-            dict: Updated resource.
-        """
-        return self._client.patch(id_or_uri, operation, path, value, timeout=timeout)
+        uri = "{}/settings".format(self.data["uri"])
+        return self._helper.do_get(uri)

--- a/tests/unit/resources/networking/test_logical_interconnect_groups.py
+++ b/tests/unit/resources/networking/test_logical_interconnect_groups.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright (2012-2017) Hewlett Packard Enterprise Development LP
+# (C) Copyright (2012-2019) Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,7 +27,7 @@ import mock
 
 from hpOneView.connection import connection
 from hpOneView.resources.networking.logical_interconnect_groups import LogicalInterconnectGroups
-from hpOneView.resources.resource import ResourceClient
+from hpOneView.resources.resource import Resource, ResourceHelper, ResourcePatchMixin
 
 
 class LogicalInterconnectGroupsTest(unittest.TestCase):
@@ -35,8 +35,10 @@ class LogicalInterconnectGroupsTest(unittest.TestCase):
         self.host = '127.0.0.1'
         self.connection = connection(self.host)
         self._lig = LogicalInterconnectGroups(self.connection)
+        self.uri = "/rest/logical-interconnect-groups/f0a0a113-ec97-41b4-83ce-d7c92b900e7c"
+        self._lig.data = {"uri": self.uri}
 
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(ResourceHelper, 'get_all')
     def test_get_all_called_once(self, mock_get_all):
         filter = 'name=TestName'
         sort = 'name:ascending'
@@ -46,44 +48,24 @@ class LogicalInterconnectGroupsTest(unittest.TestCase):
 
         mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort, scope_uris=scope_uris)
 
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(ResourceHelper, 'get_all')
     def test_get_all_called_once_with_default(self, mock_get_all):
         self._lig.get_all()
         mock_get_all.assert_called_once_with(0, -1, filter='', sort='', scope_uris='')
 
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_by_id_called_once(self, mock_get):
-        lig_id = "f0a0a113-ec97-41b4-83ce-d7c92b900e7c"
-        self._lig.get(lig_id)
-        mock_get.assert_called_once_with(lig_id)
-
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_by_uri_called_once(self, mock_get):
-        lig_uri = "/rest/logical-interconnect-groups/f0a0a113-ec97-41b4-83ce-d7c92b900e7c"
-        self._lig.get(lig_uri)
-        mock_get.assert_called_once_with(lig_uri)
-
-    @mock.patch.object(ResourceClient, 'get')
+    @mock.patch.object(ResourceHelper, 'do_get')
     def test_get_default_settings_called_once(self, mock_get):
         lig_settings_uri = "/rest/logical-interconnect-groups/defaultSettings"
         self._lig.get_default_settings()
         mock_get.assert_called_once_with(lig_settings_uri)
 
-    @mock.patch.object(ResourceClient, 'get')
+    @mock.patch.object(ResourceHelper, 'do_get')
     def test_get_settings_called_once_when_lig_uri_provided(self, mock_get):
-        lig_uri = "/rest/logical-interconnect-groups/f0a0a113-ec97-41b4-83ce-d7c92b900e7c"
-        lig_settings_uri = "/rest/logical-interconnect-groups/f0a0a113-ec97-41b4-83ce-d7c92b900e7c/settings"
-        self._lig.get_settings(lig_uri)
+        lig_settings_uri = "{}/settings".format(self.uri)
+        self._lig.get_settings()
         mock_get.assert_called_once_with(lig_settings_uri)
 
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_settings_called_once_when_lig_id_provided(self, mock_get):
-        lig_id = "f0a0a113-ec97-41b4-83ce-d7c92b900e7c"
-        lig_settings_uri = "/rest/logical-interconnect-groups/f0a0a113-ec97-41b4-83ce-d7c92b900e7c/settings"
-        self._lig.get_settings(lig_id)
-        mock_get.assert_called_once_with(lig_settings_uri)
-
-    @mock.patch.object(ResourceClient, 'create')
+    @mock.patch.object(ResourceHelper, 'create')
     def test_create_called_once(self, mock_create):
         lig = {
             "type": "logical-interconnect-groupV3",
@@ -94,11 +76,12 @@ class LogicalInterconnectGroupsTest(unittest.TestCase):
             "uplinkSets": [],
             "enclosureType": "C7000",
         }
-        self._lig.create(lig, 70)
-        mock_create.assert_called_once_with(lig, timeout=70, default_values=self._lig.DEFAULT_VALUES)
+        self._lig.create(lig, timeout=70)
+        mock_create.assert_called_once_with(lig, None, 70, None)
 
-    @mock.patch.object(ResourceClient, 'update')
-    def test_update_called_once(self, mock_update):
+    @mock.patch.object(Resource, 'ensure_resource_data')
+    @mock.patch.object(ResourceHelper, 'update')
+    def test_update_called_once(self, mock_update, mock_ensure_client):
         lig = {
             "type": "logical-interconnect-groupV3",
             "name": "OneView Test Logical Interconnect Group",
@@ -108,35 +91,38 @@ class LogicalInterconnectGroupsTest(unittest.TestCase):
             "uplinkSets": [],
             "enclosureType": "C7000",
         }
-        self._lig.update(lig, 70)
-        mock_update.assert_called_once_with(lig, timeout=70, default_values=self._lig.DEFAULT_VALUES)
+        self._lig.update(lig, timeout=70)
 
-    @mock.patch.object(ResourceClient, 'delete')
+        lig["uri"] = self.uri
+
+        mock_update.assert_called_once_with(lig, self.uri, False, 70, None)
+
+    @mock.patch.object(ResourceHelper, 'delete')
     def test_delete_called_once(self, mock_delete):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
-        self._lig.delete(id, force=True, timeout=50)
+        self._lig.delete(force=True, timeout=50)
 
-        mock_delete.assert_called_once_with(id, force=True, timeout=50)
+        mock_delete.assert_called_once_with(self.uri, custom_headers=None,
+                                            force=True, timeout=50)
 
-    @mock.patch.object(ResourceClient, 'delete')
+    @mock.patch.object(ResourceHelper, 'delete')
     def test_delete_called_once_with_defaults(self, mock_delete):
-        id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
-        self._lig.delete(id)
+        self._lig.delete()
 
-        mock_delete.assert_called_once_with(id, force=False, timeout=-1)
+        mock_delete.assert_called_once_with(self.uri, custom_headers=None,
+                                            force=False, timeout=-1)
 
-    @mock.patch.object(ResourceClient, 'get_by')
-    def test_get_by_called_once(self, mock_get_by):
-        self._lig.get_by("name", "test name")
-
-        mock_get_by.assert_called_once_with("name", "test name")
-
-    @mock.patch.object(ResourceClient, 'patch')
+    @mock.patch.object(ResourcePatchMixin, 'patch_request')
     def test_patch_should_use_user_defined_values(self, mock_patch):
         mock_patch.return_value = {}
 
-        self._lig.patch('rest/fake/lig123', 'replace',
-                        '/scopeUris', ['rest/fake/scope123'], 1)
+        self._lig.patch('replace',
+                        '/scopeUris',
+                        ['rest/fake/scope123'],
+                        timeout=-1)
 
-        mock_patch.assert_called_once_with('rest/fake/lig123', 'replace',
-                                           '/scopeUris', ['rest/fake/scope123'], timeout=1)
+        mock_patch.assert_called_once_with(self.uri,
+                                           body=[{'path': '/scopeUris',
+                                                  'value': ['rest/fake/scope123'],
+                                                  'op': 'replace'}],
+                                           custom_headers=None,
+                                           timeout=-1)


### PR DESCRIPTION
### Description
Upgraded Logical Interconnect groups resource to support OneView API version 800

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
