### PR TITLE
override for type in migratable_vc_domains

### DIFF
--- a/examples/migratable_vc_domains.py
+++ b/examples/migratable_vc_domains.py
@@ -29,16 +29,16 @@ from pprint import PrettyPrinter
 
 
 config = {
-    "ip": "172.16.102.59",
+    "ip": "172.168.100.251",
     "credentials": {
         "userName": "Administrator",
-        "password": ""
+        "password": "GSE#admin1"
     },
-    "enclosure_hostname": "172.178.209.32",
+    "enclosure_hostname": "172.168.100.32",
     "enclosure_username": "Administrator",
-    "enclosure_password": "",
+    "enclosure_password": "Password",
     "vcmUsername": "Administrator",
-    "vcmPassword": "",
+    "vcmPassword": "Password",
     "enclosure_group_uri": None
 }
 
@@ -57,6 +57,7 @@ migrationInformation = MigratableVcDomains.make_migration_information(config['en
                                                                       config['enclosure_username'],
                                                                       config['enclosure_password'],
                                                                       config['vcmUsername'], config['vcmPassword'],
+																	  type = 'MigratableVcDomainV300',
                                                                       enclosureGroupUri=config['enclosure_group_uri'])
 
 # Start a migration by first creating a compatibility report

--- a/hpOneView/resources/servers/migratable_vc_domains.py
+++ b/hpOneView/resources/servers/migratable_vc_domains.py
@@ -49,7 +49,7 @@ class MigratableVcDomains(object):
 
     @staticmethod
     def make_migration_information(oaIpAddress, oaUsername, oaPassword, vcmUsername, vcmPassword,
-                                   iloLicenseType='OneView', enclosureGroupUri=None):
+									type = 'migratable-vc-domains', iloLicenseType='OneView', enclosureGroupUri=None):
         return {
             'credentials': {
                 'oaIpAddress': oaIpAddress,
@@ -61,7 +61,7 @@ class MigratableVcDomains(object):
             },
             'iloLicenseType': iloLicenseType,
             'enclosureGroupUri': enclosureGroupUri,
-            'type': 'migratable-vc-domains',
+            'type': type,
             'category': 'migratable-vc-domains'
         }
 


### PR DESCRIPTION
### Description
[Describe what this change achieves]
The code has been changed in :
1) python-hpOneView\hpOneView\resources\servers\migratable_vc_domains.py
	The change is in the function "make_migration_information" wherein a parameter has been
	added with the default value for 'type' as 'migratable-vc-domains'.

2) python-hpOneView\examples\migratable_vc_domains.py
	The call to the above function will have a parameter passed as "type = 'MigratableVcDomainV300' "

### Issues Resolved
[List any issues this PR will resolve. e.g., Fixes #01]
Issue #431

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [ ] Changes are documented in the CHANGELOG.
