### PR TITLE
Scope URIs query parameter for server hardware 

### DIFF
--- a/hpOneView/resources/servers/server_hardware.py
+++ b/hpOneView/resources/servers/server_hardware.py
@@ -131,7 +131,7 @@ class ServerHardware(object):
 
         return self._client.get_utilization(id_or_uri, fields=fields, filter=filter, refresh=refresh, view=view)
 
-    def get_all(self, start=0, count=-1, filter='', sort=''):
+    def get_all(self, start=0, count=-1, filter='', sort='', scope_uris=''):
         """
         Gets a list of server hardware resources. Returns a list of resources based on optional sorting and filtering,
         and constrained by start and count parameters.
@@ -154,7 +154,7 @@ class ServerHardware(object):
         Returns:
             list: A list of server hardware resources.
         """
-        return self._client.get_all(start, count, filter=filter, sort=sort)
+        return self._client.get_all(start, count, filter=filter, sort=sort, scope_uris=scope_uris)
 
     def add(self, information, timeout=-1):
         """

--- a/tests/unit/resources/servers/test_server_hardware.py
+++ b/tests/unit/resources/servers/test_server_hardware.py
@@ -57,16 +57,17 @@ class ServerHardwareTest(TestCase):
     def test_get_all_called_once(self, mock_get_all):
         filter = 'name=TestName'
         sort = 'name:ascending'
+        scope_uris = '/rest/test/scopes'
 
-        self._server_hardware.get_all(2, 500, filter, sort)
+        self._server_hardware.get_all(2, 500, filter, sort, scope_uris)
 
-        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort)
+        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort, scope_uris=scope_uris)
 
     @mock.patch.object(ResourceClient, 'get_all')
     def test_get_all_called_once_with_default_values(self, mock_get_all):
         self._server_hardware.get_all()
 
-        mock_get_all.assert_called_once_with(0, -1, filter='', sort='')
+        mock_get_all.assert_called_once_with(0, -1, filter='', sort='', scope_uris='')
 
     @mock.patch.object(ResourceClient, 'get_by')
     def test_get_by_called_once(self, mock_get_by):


### PR DESCRIPTION
### Description
Adds scope uris query parameter for server hardware. Through this user will be able to retrieve ll the server based on a given scope URI.

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [ ] Changes are documented in the CHANGELOG.
