### PR TITLE
Extend FirmwareBundles.update to upload compsig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Extends support of the SDK to OneView Rest API version 800 (OneView v4.1).
 - Ethernet network
 - FC network
 - FCOE network
+- Firmware bundle signature upload
 - Interconnect type
 - Internal link set
 - Logical enclosure

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -18,8 +18,8 @@
 
 ## HPE OneView
 
-| Endpoints                                                                       | Verb     | V200 | V300 | V500 | V600 | V800
-| --------------------------------------------------------------------------------------- | -------- | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: |
+| Endpoints                                                                       | Verb     | V200 | V300 | V500 | V600 | V800 | V1000 | V1200
+| --------------------------------------------------------------------------------------- | -------- | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: | :------------------: |
 |     **Alerts**                                                                                                                                   |
 |<sub>/rest/alerts	</sub>                                                                |GET       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/alerts	</sub>                                                                |DELETE    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
@@ -154,10 +154,11 @@
 |<sub>/rest/fcoe-networks/{id}</sub>                                                      | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/fcoe-networks/{id}</sub>                                                      | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Firmware Bundles**                                                                                                                          |
-|<sub>/rest/firmware-bundles</sub>                                                       | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/firmware-bundles</sub>                                                        | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/firmware-bundles/addCompsig</sub>                                             | POST     | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   |
 |     **Firmware Drivers**                                                                                                                          |
-|<sub>/rest/firmware-drivers</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/firmware-drivers</sub>                                                       | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/firmware-drivers</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/firmware-drivers</sub>                                                        | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/firmware-drivers/{id}</sub>                                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/firmware-drivers/{id}</sub>                                                   | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **ID Pools**                                                                                                                      |

--- a/examples/firmware_bundles.py
+++ b/examples/firmware_bundles.py
@@ -34,8 +34,10 @@ config = {
     }
 }
 
-# To run this example you must define a path to a valid file
-firmware_path = "<path_to_firmware_bundle>"
+# Example updates - change to what you want to upload
+spp_path = "SPPgen9snap6.2015_0405.81.iso"
+patch_path = "CP036110.zip"
+compsig_path = "CP036110.compsig"
 
 # Try load config from a file (if there is a config file)
 config = try_load_from_file(config)
@@ -43,6 +45,18 @@ oneview_client = OneViewClient(config)
 
 # Upload a firmware bundle
 print("\nUpload a firmware bundle")
-firmware_bundle_information = oneview_client.firmware_bundles.upload(file_path=firmware_path)
+
+# Upload an entire SPP
+(bundle_information, compsig_information) = oneview_client.firmware_bundles.upload(file_path=spp_path)
+
 print("\n Upload successful! Firmware information returned: \n")
-pprint(firmware_bundle_information)
+pprint(bundle_information)
+
+# Upload just a single patch
+(bundle_information, compsig_information) = oneview_client.firmware_bundles.upload(
+    file_path=patch_path, compsig_path=compsig_path)
+
+print("\n Upload successful! Firmware information returned: \n")
+pprint(bundle_information)
+print("\n Firmware information returned: \n")
+pprint(compsig_information)


### PR DESCRIPTION
### Description
When uploading a single patch (e.g. cp01234.zip instead of SPP.iso) a compsig file is needed. Since API 1000 OneView allows to do this.

Is master the correct/latest branch?

I'd extend the tests in https://github.com/HewlettPackard/python-hpOneView/blob/release/v4.8.0/tests/unit/resources/settings/test_firmware_bundles.py but I'm not sure where `SPPgen9snap6.2015_0405.81.iso` is coming from and how I could add my own.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
